### PR TITLE
[WOR-221] Migrate dashboard icons to Hugeicons free

### DIFF
--- a/dashboard/app/package.json
+++ b/dashboard/app/package.json
@@ -57,11 +57,12 @@
     "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "dependencies": {
+    "@hugeicons/core-free-icons": "^4.2.3",
+    "@hugeicons/react": "^1.1.9",
     "@mantine/charts": "^8.3.18",
     "@mantine/core": "^8.3.14",
     "@mantine/hooks": "^8.3.14",
     "@mantine/notifications": "^8.3.18",
-    "@phosphor-icons/react": "^2.1.10",
     "@workhorse/dashboard-server": "workspace:*",
     "recharts": "^3.10.1"
   },

--- a/dashboard/app/src/dashboard.tsx
+++ b/dashboard/app/src/dashboard.tsx
@@ -35,28 +35,30 @@ import {
 import { BarChart } from "@mantine/charts";
 import { useDisclosure, useMediaQuery } from "@mantine/hooks";
 import {
-  ArrowCounterClockwise,
-  ArrowClockwise,
-  CalendarDots,
-  CheckCircle,
-  Clock,
-  Copy,
-  DotsThreeVertical,
-  FunnelSimple,
-  GearSix,
-  Info,
-  Lightning,
-  ListDashes,
-  ListChecks,
-  MagnifyingGlass,
-  PlayCircle,
-  Prohibit,
-  Pulse,
-  Robot,
-  UserFocus,
-  WarningCircle,
-  XCircle,
-} from "@phosphor-icons/react";
+  ActivityIcon,
+  CalendarIcon,
+  CheckCircleIcon,
+  ClockIcon,
+  CopyIcon,
+  DiscardedIcon,
+  FilterIconGlyph,
+  HumanWaitIcon,
+  InfoIcon,
+  LightningIcon,
+  PlayIcon,
+  ProhibitIcon,
+  QueuedIcon,
+  RefreshIconGlyph,
+  RetryIcon,
+  RowMenuIcon,
+  SearchIcon,
+  SettingsIcon,
+  TaskListIcon,
+  WarningIcon,
+  WorkerIcon,
+  iconSize,
+  type DashboardIcon,
+} from "./icons.js";
 import {
   createContext,
   Fragment,
@@ -350,20 +352,20 @@ const taskFilterPresentation: Record<
   DashboardTaskFilter,
   {
     label: string;
-    icon: typeof ListChecks;
+    icon: DashboardIcon;
   }
 > = {
-  all: { label: "All tasks", icon: ListChecks },
-  blocked: { label: "Blocked", icon: WarningCircle },
-  waiting: { label: "Waiting", icon: UserFocus },
-  scheduled: { label: "Scheduled", icon: Clock },
-  retried: { label: "Retried", icon: ArrowCounterClockwise },
-  queued: { label: "Queued", icon: ListDashes },
-  running: { label: "Running", icon: PlayCircle },
-  completed: { label: "Completed", icon: CheckCircle },
-  discarded: { label: "Discarded", icon: XCircle },
+  all: { label: "All tasks", icon: TaskListIcon },
+  blocked: { label: "Blocked", icon: WarningIcon },
+  waiting: { label: "Waiting", icon: HumanWaitIcon },
+  scheduled: { label: "Scheduled", icon: ClockIcon },
+  retried: { label: "Retried", icon: RetryIcon },
+  queued: { label: "Queued", icon: QueuedIcon },
+  running: { label: "Running", icon: PlayIcon },
+  completed: { label: "Completed", icon: CheckCircleIcon },
+  discarded: { label: "Discarded", icon: DiscardedIcon },
   // Cancellation is a distinct terminal state, never folded into discarded work.
-  canceled: { label: "Canceled", icon: Prohibit },
+  canceled: { label: "Canceled", icon: ProhibitIcon },
 };
 const taskFilters = dashboardTaskFilters.map((value) => ({
   value,
@@ -752,7 +754,11 @@ function JsonValue({
               aria-label={copied ? `${copyLabel} copied to the clipboard` : `Copy ${copyLabel}`}
               onClick={copy}
             >
-              {copied ? <CheckCircle size={14} weight="bold" /> : <Copy size={14} />}
+              {copied ? (
+                <CheckCircleIcon size={iconSize.control} weight="bold" />
+              ) : (
+                <CopyIcon size={iconSize.control} />
+              )}
             </ActionIcon>
           </Tooltip>
         ) : null}
@@ -921,7 +927,7 @@ function PlannedDurability({ job }: { job: DashboardJobDetail }) {
         /* State is carried by the heading text and the icon, never by colour alone. */
         <Paper withBorder p="xs" mb="sm">
           <Group gap={6} align="center" wrap="nowrap" mb={2}>
-            <Prohibit size={13} weight="bold" aria-hidden />
+            <ProhibitIcon size={iconSize.bullet} weight="bold" aria-hidden />
             <Text fw={600} size="xs">
               {hasEvidencePastPersistentBoundary
                 ? "Earlier demo evidence detected"
@@ -943,13 +949,13 @@ function PlannedDurability({ job }: { job: DashboardJobDetail }) {
         color="violet"
         iconSize={28}
         allowNextStepsSelect={false}
-        completedIcon={<CheckCircle size={15} weight="bold" />}
+        completedIcon={<CheckCircleIcon size={iconSize.marker} weight="bold" />}
         progressIcon={
           // A blocked task is not waiting for anything, so it never shows a waiting clock.
           persistentFailure && !hasEvidencePastPersistentBoundary ? (
-            <Prohibit size={14} weight="bold" style={{ display: "block" }} />
+            <ProhibitIcon size={iconSize.control} weight="bold" style={{ display: "block" }} />
           ) : (
-            <Clock size={14} weight="bold" style={{ display: "block" }} />
+            <ClockIcon size={iconSize.control} weight="bold" style={{ display: "block" }} />
           )
         }
       >
@@ -1516,7 +1522,7 @@ function CancelTaskPanel({
           <Button
             size="xs"
             variant="default"
-            leftSection={<Prohibit size={14} />}
+            leftSection={<ProhibitIcon size={iconSize.control} />}
             disabled={pending}
             onClick={() => setConfirming(true)}
           >
@@ -1594,7 +1600,11 @@ function TaskIdChip({ id }: { id: string }) {
               aria-label={copied ? "Task id copied to the clipboard" : "Copy task id"}
               onClick={copy}
             >
-              {copied ? <CheckCircle size={12} weight="bold" /> : <Copy size={12} />}
+              {copied ? (
+                <CheckCircleIcon size={iconSize.inline} weight="bold" />
+              ) : (
+                <CopyIcon size={iconSize.inline} />
+              )}
             </ActionIcon>
           </Tooltip>
         )}
@@ -2338,7 +2348,7 @@ function CancelRequestedBadge({
       size="sm"
       variant="light"
       color="gray"
-      leftSection={<Prohibit size={11} weight="bold" />}
+      leftSection={<ProhibitIcon size={iconSize.chip} weight="bold" />}
       tt="none"
       title={`${described.exact} Requested ${formatExact(cancellation.requestedAt)}.`}
       role="status"
@@ -2498,7 +2508,7 @@ export function TaskWaitBadge({ job }: { job: DashboardJobRow }) {
         size="sm"
         variant="light"
         color="violet"
-        leftSection={<Lightning size={11} weight="bold" />}
+        leftSection={<LightningIcon size={iconSize.chip} weight="bold" />}
         tt="none"
         title={`Waiting for signal ${job.signalWait.name} · deadline ${formatExact(job.signalWait.deadlineAt)}`}
         role="status"
@@ -2515,7 +2525,7 @@ export function TaskWaitBadge({ job }: { job: DashboardJobRow }) {
         size="sm"
         variant="light"
         color="violet"
-        leftSection={<UserFocus size={11} weight="bold" />}
+        leftSection={<HumanWaitIcon size={iconSize.chip} weight="bold" />}
         tt="none"
         title={`Waiting for decision ${job.humanWait.name} · deadline ${formatExact(job.humanWait.deadlineAt)}`}
         role="status"
@@ -2532,7 +2542,7 @@ export function TaskWaitBadge({ job }: { job: DashboardJobRow }) {
       size="sm"
       variant="light"
       color={due ? "cyan" : "indigo"}
-      leftSection={<Clock size={11} weight="bold" />}
+      leftSection={<ClockIcon size={iconSize.chip} weight="bold" />}
       tt="none"
       title={`Durable wait ${scheduledWait.name} · not before ${formatExact(scheduledWait.wakeAt)}`}
       role="status"
@@ -2568,7 +2578,7 @@ function EmptyState({ children }: { children: ReactNode }) {
       <Center mih={180}>
         <Stack align="center" gap="xs">
           <ThemeIcon variant="light" color="gray" size="xl" radius="xl">
-            <CheckCircle size={22} />
+            <CheckCircleIcon size={iconSize.feature} />
           </ThemeIcon>
           <Text fw={600}>No results</Text>
           <Text c="dimmed" size="sm">
@@ -2820,7 +2830,7 @@ export function TaskListingFilters({
         size="xs"
         value={searchInput}
         onChange={(event) => setSearchInput(event.currentTarget.value)}
-        leftSection={<MagnifyingGlass size={14} />}
+        leftSection={<SearchIcon size={iconSize.control} />}
         placeholder="Search tasks. Use * as a wildcard."
         aria-label="Search tasks"
         style={{ flex: "1 1 220px" }}
@@ -2880,12 +2890,12 @@ export function TaskListingFilters({
 }
 
 function taskRowActionIcon(id: TaskRowActionId): ReactNode {
-  if (id === "inspect") return <Info size={16} />;
-  if (id === "copy-id" || id === "copy-args") return <Copy size={16} />;
-  if (id === "cancel") return <Prohibit size={16} />;
-  if (id === "run-now") return <PlayCircle size={16} />;
-  if (id === "complete-human-wait") return <CheckCircle size={16} />;
-  return <FunnelSimple size={16} />;
+  if (id === "inspect") return <InfoIcon size={iconSize.menu} />;
+  if (id === "copy-id" || id === "copy-args") return <CopyIcon size={iconSize.menu} />;
+  if (id === "cancel") return <ProhibitIcon size={iconSize.menu} />;
+  if (id === "run-now") return <PlayIcon size={iconSize.menu} />;
+  if (id === "complete-human-wait") return <CheckCircleIcon size={iconSize.menu} />;
+  return <FilterIconGlyph size={iconSize.menu} />;
 }
 
 /**
@@ -2927,7 +2937,7 @@ function TaskRowActions({
           // The row itself opens the drawer on click, which is not what opening this menu means.
           onClick={(event) => event.stopPropagation()}
         >
-          <DotsThreeVertical size={16} weight="bold" />
+          <RowMenuIcon size={iconSize.menu} weight="bold" />
         </ActionIcon>
       </Menu.Target>
       <Menu.Dropdown onClick={(event) => event.stopPropagation()}>
@@ -3184,7 +3194,7 @@ function TasksPage({
                       variant="default"
                       size="xs"
                       radius="xl"
-                      leftSection={<PlayCircle size={16} />}
+                      leftSection={<PlayIcon size={iconSize.menu} />}
                       loading={runningDemoJob !== null}
                     >
                       Enqueue test task
@@ -3194,25 +3204,25 @@ function TasksPage({
                   <Menu.Dropdown style={{ maxHeight: "min(560px, 80vh)", overflowY: "auto" }}>
                     <Menu.Label>Test outcome</Menu.Label>
                     <Menu.Item
-                      leftSection={<CheckCircle size={16} />}
+                      leftSection={<CheckCircleIcon size={iconSize.menu} />}
                       onClick={() => void enqueueTestTask("success")}
                     >
                       Succeed
                     </Menu.Item>
                     <Menu.Item
-                      leftSection={<ArrowCounterClockwise size={16} />}
+                      leftSection={<RetryIcon size={iconSize.menu} />}
                       onClick={() => void enqueueTestTask("retry")}
                     >
                       Fail once, then retry
                     </Menu.Item>
                     <Menu.Item
-                      leftSection={<CheckCircle size={16} />}
+                      leftSection={<CheckCircleIcon size={iconSize.menu} />}
                       onClick={() => void enqueueTestTask("idempotent")}
                     >
                       Reuse one task for repeat requests
                     </Menu.Item>
                     <Menu.Item
-                      leftSection={<ListChecks size={16} />}
+                      leftSection={<TaskListIcon size={iconSize.menu} />}
                       onClick={() =>
                         void enqueueTestTask("durable", { scenario: "order-fulfillment" })
                       }
@@ -3220,7 +3230,7 @@ function TasksPage({
                       Durable · order fulfillment · 4 steps
                     </Menu.Item>
                     <Menu.Item
-                      leftSection={<ListChecks size={16} />}
+                      leftSection={<TaskListIcon size={iconSize.menu} />}
                       onClick={() =>
                         void enqueueTestTask("durable", { scenario: "customer-onboarding" })
                       }
@@ -3228,7 +3238,7 @@ function TasksPage({
                       Durable · customer onboarding · 3 steps
                     </Menu.Item>
                     <Menu.Item
-                      leftSection={<ListChecks size={16} />}
+                      leftSection={<TaskListIcon size={iconSize.menu} />}
                       onClick={() =>
                         void enqueueTestTask("durable", { scenario: "report-publication" })
                       }
@@ -3236,26 +3246,26 @@ function TasksPage({
                       Durable · report publication · 3 steps
                     </Menu.Item>
                     <Menu.Item
-                      leftSection={<Clock size={16} />}
+                      leftSection={<ClockIcon size={iconSize.menu} />}
                       onClick={() => void enqueueTestTask("timer")}
                     >
                       Durable wait · named timer boundary
                     </Menu.Item>
                     <Menu.Item
-                      leftSection={<XCircle size={16} />}
+                      leftSection={<DiscardedIcon size={iconSize.menu} />}
                       color="red"
                       onClick={() => void enqueueTestTask("failure")}
                     >
                       Terminal failure
                     </Menu.Item>
                     <Menu.Item
-                      leftSection={<ArrowCounterClockwise size={16} />}
+                      leftSection={<RetryIcon size={iconSize.menu} />}
                       onClick={() => void enqueueTestTask("redrive")}
                     >
                       Redrive newest dead letter
                     </Menu.Item>
                     <Menu.Item
-                      leftSection={<Clock size={16} />}
+                      leftSection={<ClockIcon size={iconSize.menu} />}
                       onClick={() => void enqueueTestTask("long-running")}
                     >
                       Long-running · 20s
@@ -3265,7 +3275,7 @@ function TasksPage({
                     {dashboardDemoFeatureExamples.map(({ feature, label }) => (
                       <Menu.Item
                         key={feature}
-                        leftSection={<Lightning size={16} />}
+                        leftSection={<LightningIcon size={iconSize.menu} />}
                         onClick={() => void enqueueTestTask("feature", { feature })}
                       >
                         {label}
@@ -3894,7 +3904,7 @@ function HelpButton({ label, help }: { label: string; help: string }) {
   return (
     <Tooltip label={help} multiline w={280} withArrow>
       <ActionIcon aria-label={`${label}: ${help}`} color="gray" size="sm" variant="subtle">
-        <Info size={14} />
+        <InfoIcon size={iconSize.control} />
       </ActionIcon>
     </Tooltip>
   );
@@ -4195,7 +4205,7 @@ export function SystemKpiList({
         help="This rate compares finished tasks with new tasks during the selected window. A negative net means tasks arrived faster than workers finished them."
         scope={data.window}
         color={data.kpis.drain.netPerMinute < 0 ? "yellow" : "teal"}
-        icon={<ArrowClockwise size={16} />}
+        icon={<RefreshIconGlyph size={iconSize.menu} />}
       >
         <MiniTrend
           series={[
@@ -4218,7 +4228,7 @@ export function SystemKpiList({
         help="This count shows tasks that are ready for workers. An older task can mean that its queue is draining slowly."
         scope="now"
         color={backlogColor}
-        icon={<ListChecks size={16} />}
+        icon={<TaskListIcon size={iconSize.menu} />}
       />
       <HealthKpi
         divided
@@ -4228,7 +4238,7 @@ export function SystemKpiList({
         help="This is the share of attempts that did not succeed. The comparison uses the previous window of the same length."
         scope={data.window}
         color={errorColor}
-        icon={<WarningCircle size={16} />}
+        icon={<WarningIcon size={iconSize.menu} />}
       />
       <HealthKpi
         divided
@@ -4251,7 +4261,7 @@ export function SystemKpiList({
         help="These percentiles measure the time between enqueue and first claim during the selected window."
         scope={data.window}
         color="indigo"
-        icon={<Clock size={16} />}
+        icon={<ClockIcon size={iconSize.menu} />}
       />
       <HealthKpi
         divided
@@ -4261,7 +4271,7 @@ export function SystemKpiList({
         help="This count shows tasks in backoff before another attempt. The second count shows how many become ready within five minutes."
         scope="now"
         color={data.kpis.retry.dueSoon > 0 ? "orange" : "blue"}
-        icon={<ArrowCounterClockwise size={16} />}
+        icon={<RetryIcon size={iconSize.menu} />}
       />
       <HealthKpi
         divided
@@ -4271,7 +4281,7 @@ export function SystemKpiList({
         help="This count shows active tasks whose leases expired. It also shows leases nearing expiry and tasks recovered during the selected window."
         scope="now"
         color={data.kpis.lease.expired > 0 ? "red" : "teal"}
-        icon={<Pulse size={16} />}
+        icon={<ActivityIcon size={iconSize.menu} />}
       />
       <HealthKpi
         divided
@@ -4287,7 +4297,7 @@ export function SystemKpiList({
               ? "orange"
               : "teal"
         }
-        icon={<Clock size={16} />}
+        icon={<ClockIcon size={iconSize.menu} />}
       />
       <HealthKpi
         divided
@@ -4318,7 +4328,7 @@ export function SystemKpiList({
               ? "yellow"
               : "teal"
         }
-        icon={<FunnelSimple size={16} />}
+        icon={<FilterIconGlyph size={iconSize.menu} />}
       />
       <HealthKpi
         divided
@@ -4334,7 +4344,7 @@ export function SystemKpiList({
               ? "yellow"
               : "teal"
         }
-        icon={<UserFocus size={16} />}
+        icon={<HumanWaitIcon size={iconSize.menu} />}
       />
       <HealthKpi
         divided
@@ -4359,7 +4369,7 @@ export function SystemKpiList({
         help="These handlers are suspended for a signal or human decision. Overdue waits remain critical until deadline maintenance resolves them."
         scope="now"
         color={data.kpis.externalWaits.overdue > 0 ? "red" : "teal"}
-        icon={<Lightning size={16} />}
+        icon={<LightningIcon size={iconSize.menu} />}
       />
     </Paper>
   );
@@ -4375,7 +4385,11 @@ export function ExternalWaitAlert({
   if (externalWaits.overdue === 0) return null;
 
   return (
-    <Alert color="red" icon={<WarningCircle size={18} />} title="External waits are overdue">
+    <Alert
+      color="red"
+      icon={<WarningIcon size={iconSize.navigation} />}
+      title="External waits are overdue"
+    >
       <Group justify="space-between" align="center">
         <Text size="sm">
           A signal or human decision passed its deadline. Deadline maintenance will resolve the
@@ -7041,7 +7055,7 @@ function useDashboardController(
     content = (
       <Center mih="60vh">
         <Stack align="center" gap="sm">
-          <WarningCircle size={28} color="var(--mantine-color-red-6)" />
+          <WarningIcon size={iconSize.page} color="var(--mantine-color-red-6)" />
           <Text fw={600}>Workhorse could not load this page.</Text>
           <Text c="dimmed" size="sm">
             {loadState.error}
@@ -7286,7 +7300,7 @@ function DashboardContent({
                 variant="default"
                 size="xs"
                 w={120}
-                leftSection={<ArrowClockwise size={14} />}
+                leftSection={<RefreshIconGlyph size={iconSize.control} />}
                 loading={loading}
                 onClick={() => {
                   resetRefreshSchedule();
@@ -7324,7 +7338,9 @@ function DashboardContent({
                       key={option.value}
                       onClick={() => changeRefreshInterval(option.value)}
                       rightSection={
-                        refreshInterval === option.value ? <CheckCircle size={14} /> : null
+                        refreshInterval === option.value ? (
+                          <CheckCircleIcon size={iconSize.control} />
+                        ) : null
                       }
                     >
                       {option.label}
@@ -7353,7 +7369,7 @@ function DashboardContent({
                   <Button
                     variant="default"
                     size="xs"
-                    leftSection={<UserFocus size={14} />}
+                    leftSection={<HumanWaitIcon size={iconSize.control} />}
                     aria-label={`Signed in as ${auditActor}`}
                   >
                     {auditActor}
@@ -7384,9 +7400,9 @@ function DashboardContent({
               variant="light"
               leftSection={
                 loadState.status === "error" ? (
-                  <WarningCircle size={12} />
+                  <WarningIcon size={iconSize.inline} />
                 ) : (
-                  <CheckCircle size={12} />
+                  <CheckCircleIcon size={iconSize.inline} />
                 )
               }
               visibleFrom="xs"
@@ -7455,7 +7471,7 @@ function DashboardContent({
               href={mountedHref(basePath, "/events")}
               active={location.route === "/events"}
               label="Events"
-              leftSection={<Lightning size={18} />}
+              leftSection={<LightningIcon size={iconSize.navigation} />}
               variant="light"
               onClick={(event) => handleLink(event, "/events")}
             />
@@ -7464,7 +7480,7 @@ function DashboardContent({
               href={mountedHref(basePath, "/cron")}
               active={location.route === "/cron"}
               label="Schedules"
-              leftSection={<CalendarDots size={18} />}
+              leftSection={<CalendarIcon size={iconSize.navigation} />}
               variant="light"
               onClick={(event) => handleLink(event, "/cron")}
             />
@@ -7473,7 +7489,7 @@ function DashboardContent({
               href={mountedHref(basePath, "/queues")}
               active={location.route === "/queues"}
               label="Queues"
-              leftSection={<ListDashes size={18} />}
+              leftSection={<QueuedIcon size={iconSize.navigation} />}
               variant="light"
               onClick={(event) => handleLink(event, "/queues")}
             />
@@ -7482,7 +7498,7 @@ function DashboardContent({
               href={mountedHref(basePath, "/system")}
               active={location.route === "/system"}
               label="System health"
-              leftSection={<Pulse size={18} />}
+              leftSection={<ActivityIcon size={iconSize.navigation} />}
               variant="light"
               onClick={(event) => handleLink(event, "/system")}
             />
@@ -7491,7 +7507,7 @@ function DashboardContent({
               href={mountedHref(basePath, "/workers")}
               active={location.route === "/workers"}
               label="Workers"
-              leftSection={<Robot size={18} />}
+              leftSection={<WorkerIcon size={iconSize.navigation} />}
               variant="light"
               onClick={(event) => handleLink(event, "/workers")}
             />
@@ -7500,7 +7516,7 @@ function DashboardContent({
               href={mountedHref(basePath, "/settings")}
               active={location.route === "/settings"}
               label="Settings"
-              leftSection={<GearSix size={18} />}
+              leftSection={<SettingsIcon size={iconSize.navigation} />}
               variant="light"
               onClick={(event) => handleLink(event, "/settings")}
             />

--- a/dashboard/app/src/icons.test.tsx
+++ b/dashboard/app/src/icons.test.tsx
@@ -1,0 +1,84 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import * as icons from "./icons.js";
+import { iconSize, iconStroke, type DashboardIcon } from "./icons.js";
+
+const sourceDirectory = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * The icon module is the dashboard's single seam onto an icon vendor. These tests hold that seam
+ * shut: every icon it advertises has to draw something, and no screen may reach past it to the
+ * vendor. Without the second test the module is only a convention, and one direct import in a new
+ * screen quietly restores the per-call-site coupling this module exists to remove.
+ */
+
+const iconComponents = Object.entries(icons).filter(
+  (entry): entry is [string, DashboardIcon] => typeof entry[1] === "function",
+);
+
+describe("dashboard icon module", () => {
+  it("exports every icon the dashboard draws", () => {
+    // A floor rather than an exact count, so adding an icon does not fail this test while
+    // deleting the module's contents wholesale does.
+    expect(iconComponents.length).toBeGreaterThanOrEqual(24);
+  });
+
+  it.each(iconComponents)("renders %s as an svg", (_name, Icon) => {
+    const markup = renderToStaticMarkup(createElement(Icon));
+    expect(markup).toContain("<svg");
+    // An icon that renders an empty frame passes a "did it render" check while showing nothing,
+    // so require actual drawing instructions inside it.
+    expect(markup).toMatch(/<(path|circle|rect|line|polyline|polygon|ellipse)\b/);
+  });
+
+  it("applies the named size and stroke tokens", () => {
+    const markup = renderToStaticMarkup(
+      createElement(icons.CheckCircleIcon, { size: iconSize.navigation, weight: "bold" }),
+    );
+    expect(markup).toContain(`width="${iconSize.navigation}"`);
+    expect(markup).toContain(`height="${iconSize.navigation}"`);
+    expect(markup).toContain(`stroke-width="${iconStroke.bold}"`);
+  });
+
+  it("defaults to the menu size and the regular stroke", () => {
+    const markup = renderToStaticMarkup(createElement(icons.InfoIcon));
+    expect(markup).toContain(`width="${iconSize.menu}"`);
+    expect(markup).toContain(`stroke-width="${iconStroke.regular}"`);
+  });
+
+  it("passes presentation attributes through to the svg", () => {
+    const markup = renderToStaticMarkup(
+      createElement(icons.WarningIcon, { color: "red", "aria-hidden": true }),
+    );
+    expect(markup).toContain('aria-hidden="true"');
+    expect(markup).toContain("red");
+  });
+
+  // This file names both packages in its own assertions, so scanning it would always report a
+  // match. The module under test and this test are the two files allowed to name a vendor.
+  const scannedSources = readdirSync(sourceDirectory).filter(
+    (file) =>
+      (file.endsWith(".ts") || file.endsWith(".tsx")) &&
+      file !== "icons.tsx" &&
+      file !== "icons.test.tsx",
+  );
+
+  it("is the only module that imports an icon package", () => {
+    const iconPackage = /from\s+["'](@hugeicons\/[^"']+|@phosphor-icons\/[^"']+)["']/;
+    const offenders = scannedSources.filter((file) =>
+      iconPackage.test(readFileSync(join(sourceDirectory, file), "utf8")),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("has removed the previous icon library from the dashboard source", () => {
+    const offenders = scannedSources.filter((file) =>
+      readFileSync(join(sourceDirectory, file), "utf8").includes("@phosphor-icons"),
+    );
+    expect(offenders).toEqual([]);
+  });
+});

--- a/dashboard/app/src/icons.tsx
+++ b/dashboard/app/src/icons.tsx
@@ -1,0 +1,177 @@
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Alert02Icon,
+  ArrowTurnBackwardIcon,
+  Calendar03Icon,
+  Cancel01Icon,
+  CancelCircleIcon,
+  CheckListIcon,
+  CheckmarkCircle02Icon,
+  Clock01Icon,
+  Copy01Icon,
+  FilterIcon,
+  FlashIcon,
+  InformationCircleIcon,
+  LeftToRightListDashIcon,
+  Moon02Icon,
+  MoreVerticalIcon,
+  PaintBoardIcon,
+  PlayCircleIcon,
+  Pulse01Icon,
+  RefreshIcon,
+  Robot01Icon,
+  Search01Icon,
+  Settings02Icon,
+  Sun03Icon,
+  UserCheck01Icon,
+} from "@hugeicons/core-free-icons";
+import type { IconSvgElement } from "@hugeicons/react";
+import type { CSSProperties } from "react";
+
+/**
+ * Every icon the dashboard draws, and the only module that imports an icon package.
+ *
+ * The dashboard used to import glyphs from an icon library directly at each call site, which put
+ * the vendor's export names and its per-icon prop spelling into every screen file. Migrating
+ * libraries then meant editing every screen, and a raw `size={16}` at a call site meant no two
+ * places had to agree on what "an icon in a menu row" measures. This module is the seam: screens
+ * name the meaning they want, this file decides which drawing and which measurements serve it.
+ *
+ * Names here describe what the icon means to an operator, not what it depicts, so the picture can
+ * change without a rename rippling through the screens.
+ */
+
+/**
+ * The sizes an icon is allowed to be, named for where it appears rather than for how big it is.
+ *
+ * A call site picks a role and gets the measurement that role has agreed on. Nothing outside this
+ * module states a pixel count, so changing what "a menu icon" measures is one edit here.
+ */
+export const iconSize = {
+  /** Inside a badge or a compact chip, beside text already at its smallest. */
+  chip: 11,
+  /** Beside dense inline text, such as a status line in a table cell. */
+  inline: 12,
+  /** Inside a stepper bullet, which sits between the inline and control sizes. */
+  bullet: 13,
+  /** On a control an operator clicks: a button, an action icon, a search field. */
+  control: 14,
+  /** A stepper's completed marker, one step up from a control. */
+  marker: 15,
+  /** In a menu row, a dropdown item, or a summary tile. */
+  menu: 16,
+  /** In primary navigation and page-level alerts. */
+  navigation: 18,
+  /** A feature-sized glyph, such as an empty state's badge. */
+  feature: 22,
+  /** A page-level failure that has to be seen before the sentence under it is read. */
+  page: 28,
+} as const;
+
+export type IconSize = (typeof iconSize)[keyof typeof iconSize];
+
+/**
+ * Stroke weights, named for emphasis rather than for a number.
+ *
+ * The previous library expressed emphasis as a named weight and this one expresses it as a stroke
+ * width, so the mapping lives here once instead of at each call site.
+ */
+export const iconStroke = {
+  /** The default line, for an icon that labels something. */
+  regular: 1.5,
+  /** A heavier line, for an icon that carries state an operator is scanning for. */
+  bold: 2,
+} as const;
+
+export type IconWeight = keyof typeof iconStroke;
+
+/**
+ * What every icon in this module accepts.
+ *
+ * Deliberately narrower than the underlying library's props: a call site chooses a size role and
+ * an emphasis, and may pass the presentation attributes the surrounding component needs. It cannot
+ * reach the vendor's own prop names, so those stay replaceable.
+ */
+export interface DashboardIconProps {
+  /** One of the named sizes. Defaults to the menu size, the commonest role. */
+  size?: IconSize;
+  /** Emphasis, mapped to a stroke width. Defaults to regular. */
+  weight?: IconWeight;
+  /** CSS colour, for the rare icon that carries a colour the theme does not supply. */
+  color?: string;
+  style?: CSSProperties;
+  className?: string;
+  /** Hide a purely decorative icon from assistive technology. */
+  "aria-hidden"?: boolean;
+  "aria-label"?: string;
+  role?: string;
+}
+
+/** The shape of every icon this module exports, for a caller that stores one to render later. */
+export type DashboardIcon = (props: DashboardIconProps) => React.JSX.Element;
+
+function createIcon(icon: IconSvgElement, displayName: string): DashboardIcon {
+  function DashboardIconComponent({
+    size = iconSize.menu,
+    weight = "regular",
+    ...rest
+  }: DashboardIconProps) {
+    return <HugeiconsIcon icon={icon} size={size} strokeWidth={iconStroke[weight]} {...rest} />;
+  }
+  DashboardIconComponent.displayName = displayName;
+  return DashboardIconComponent;
+}
+
+/** A successful or completed outcome. */
+export const CheckCircleIcon = createIcon(CheckmarkCircle02Icon, "CheckCircleIcon");
+/** A failure or a warning an operator has to read. */
+export const WarningIcon = createIcon(Alert02Icon, "WarningIcon");
+/** Neutral explanation, offered rather than raised. */
+export const InfoIcon = createIcon(InformationCircleIcon, "InfoIcon");
+/** A discarded task: an outcome that ended without succeeding. */
+export const DiscardedIcon = createIcon(CancelCircleIcon, "DiscardedIcon");
+/** Work that is refused or stopped: a cancellation, or a blocked task. */
+export const ProhibitIcon = createIcon(Cancel01Icon, "ProhibitIcon");
+/** Time: a schedule, a wait, or a delay. */
+export const ClockIcon = createIcon(Clock01Icon, "ClockIcon");
+/** A calendar of recurring work. */
+export const CalendarIcon = createIcon(Calendar03Icon, "CalendarIcon");
+/** Copy a value to the clipboard. */
+export const CopyIcon = createIcon(Copy01Icon, "CopyIcon");
+/** The overflow menu on a row. */
+export const RowMenuIcon = createIcon(MoreVerticalIcon, "RowMenuIcon");
+/** Filtering, and the fallback glyph for an unnamed row action. */
+export const FilterIconGlyph = createIcon(FilterIcon, "FilterIconGlyph");
+/** Settings. */
+export const SettingsIcon = createIcon(Settings02Icon, "SettingsIcon");
+/** A run, a dispatch, or throughput: the fast path through the system. */
+export const LightningIcon = createIcon(FlashIcon, "LightningIcon");
+/** Queued work waiting its turn. */
+export const QueuedIcon = createIcon(LeftToRightListDashIcon, "QueuedIcon");
+/** A list of tasks. */
+export const TaskListIcon = createIcon(CheckListIcon, "TaskListIcon");
+/** Search. */
+export const SearchIcon = createIcon(Search01Icon, "SearchIcon");
+/** Start something now. */
+export const PlayIcon = createIcon(PlayCircleIcon, "PlayIcon");
+/** Live activity and health. */
+export const ActivityIcon = createIcon(Pulse01Icon, "ActivityIcon");
+/** A worker process. */
+export const WorkerIcon = createIcon(Robot01Icon, "WorkerIcon");
+/** Work waiting on a person's decision. */
+export const HumanWaitIcon = createIcon(UserCheck01Icon, "HumanWaitIcon");
+/** Retry, or a task that has been retried. */
+export const RetryIcon = createIcon(ArrowTurnBackwardIcon, "RetryIcon");
+/** Refresh the data on screen. */
+export const RefreshIconGlyph = createIcon(RefreshIcon, "RefreshIconGlyph");
+/** The light colour theme. */
+export const LightThemeIcon = createIcon(Sun03Icon, "LightThemeIcon");
+/** The dark colour theme. */
+export const DarkThemeIcon = createIcon(Moon02Icon, "DarkThemeIcon");
+/**
+ * The colour theme control itself.
+ *
+ * Named for the colour theme rather than for "theme" alone so it cannot be confused with Mantine's
+ * `ThemeIcon` container, which several screens import to draw a tinted badge around an icon.
+ */
+export const ColorThemeIcon = createIcon(PaintBoardIcon, "ColorThemeIcon");

--- a/dashboard/app/src/notifications.tsx
+++ b/dashboard/app/src/notifications.tsx
@@ -1,6 +1,6 @@
 import { Button, Stack, Text } from "@mantine/core";
 import { Notifications, notifications } from "@mantine/notifications";
-import { CheckCircle, Info, WarningCircle } from "@phosphor-icons/react";
+import { CheckCircleIcon, InfoIcon, WarningIcon, iconSize } from "./icons.js";
 import type { ReactNode } from "react";
 import {
   cancelOutcomeTone,
@@ -57,9 +57,9 @@ const toneAutoClose: Record<DashboardResultTone, number> = {
 };
 
 function toneIcon(tone: DashboardResultTone): ReactNode {
-  if (tone === "success") return <CheckCircle size={18} weight="fill" />;
-  if (tone === "failure") return <WarningCircle size={18} weight="fill" />;
-  return <Info size={18} />;
+  if (tone === "success") return <CheckCircleIcon size={iconSize.navigation} weight="bold" />;
+  if (tone === "failure") return <WarningIcon size={iconSize.navigation} weight="bold" />;
+  return <InfoIcon size={iconSize.navigation} />;
 }
 
 /**

--- a/dashboard/app/src/theme.tsx
+++ b/dashboard/app/src/theme.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
 } from "@mantine/core";
 import { Menu } from "./dropdown-activity.js";
-import { Moon, Palette, Sun } from "@phosphor-icons/react";
+import { ColorThemeIcon, DarkThemeIcon, LightThemeIcon, iconSize } from "./icons.js";
 import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
 import { DashboardNotifications } from "./notifications.js";
 
@@ -95,8 +95,8 @@ const options: Array<{
   label: string;
   icon: ReactNode;
 }> = [
-  { value: "light", label: "Light", icon: <Sun size={14} /> },
-  { value: "dark", label: "Dark", icon: <Moon size={14} /> },
+  { value: "light", label: "Light", icon: <LightThemeIcon size={iconSize.control} /> },
+  { value: "dark", label: "Dark", icon: <DarkThemeIcon size={iconSize.control} /> },
 ];
 
 function ThemeOptionLabel({ icon, label }: { icon: ReactNode; label: string }) {
@@ -133,7 +133,7 @@ export function ThemeSchemeSwitch() {
           <Menu.Target>
             <Tooltip label="Change color theme">
               <ActionIcon variant="default" size="lg" aria-label="Change color theme">
-                <Palette size={18} />
+                <ColorThemeIcon size={iconSize.navigation} />
               </ActionIcon>
             </Tooltip>
           </Menu.Target>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,12 @@ importers:
 
   dashboard/app:
     dependencies:
+      '@hugeicons/core-free-icons':
+        specifier: ^4.2.3
+        version: 4.2.3
+      '@hugeicons/react':
+        specifier: ^1.1.9
+        version: 1.1.9(react@19.2.8)
       '@mantine/charts':
         specifier: ^8.3.18
         version: 8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.8))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@mantine/hooks@8.3.18(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(recharts@3.10.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react-is@19.2.8)(react@19.2.8)(redux@5.0.1))
@@ -77,9 +83,6 @@ importers:
       '@mantine/notifications':
         specifier: ^8.3.18
         version: 8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.8))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@mantine/hooks@8.3.18(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@phosphor-icons/react':
-        specifier: ^2.1.10
-        version: 2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@workhorse/dashboard-server':
         specifier: workspace:*
         version: link:../../typescript/dashboard-server
@@ -251,6 +254,12 @@ importers:
 
   typescript/dashboard:
     dependencies:
+      '@hugeicons/core-free-icons':
+        specifier: ^4.2.3
+        version: 4.2.3
+      '@hugeicons/react':
+        specifier: ^1.1.9
+        version: 1.1.9(react@19.2.8)
       '@mantine/charts':
         specifier: ^8.3.18
         version: 8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.8))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@mantine/hooks@8.3.18(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(recharts@3.10.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react-is@19.2.8)(react@19.2.8)(redux@5.0.1))
@@ -263,9 +272,6 @@ importers:
       '@mantine/notifications':
         specifier: ^8.3.18
         version: 8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.8))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@mantine/hooks@8.3.18(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@phosphor-icons/react':
-        specifier: ^2.1.10
-        version: 2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@workhorse/dashboard-server':
         specifier: workspace:*
         version: link:../dashboard-server
@@ -817,6 +823,14 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
+
+  '@hugeicons/core-free-icons@4.2.3':
+    resolution: {integrity: sha512-fpiU0qFZkv4ABi23xJ2m4qNr0BBfuIaYjPboN8WDA6aj9D+OzXa7eykxKOpACZRuGbDz1U9S5DsNx1d5KNnsgA==}
+
+  '@hugeicons/react@1.1.9':
+    resolution: {integrity: sha512-O+lWSWjbijoAvMCxn4K2bQWCGN5+mP1y5j+X99j23mXMj+s0X25fs71T6t9YJLaBodwmZdaewD27dzS/PiboQw==}
+    peerDependencies:
+      react: '>=16.0.0'
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2090,13 +2104,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
-
-  '@phosphor-icons/react@2.1.10':
-    resolution: {integrity: sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      react: '>= 16.8'
-      react-dom: '>= 16.8'
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -3403,6 +3410,7 @@ packages:
   cron-parser@5.6.2:
     resolution: {integrity: sha512-yJ/G1LVir6CnlkLI40CsampPLKl1SprGGlUagWtGJxewytRVYezv5xVyzzbT+Pvzx+VIRvZVF7/a0eEMTxdnTA==}
     engines: {node: '>=18'}
+    deprecated: 'Published tarball was built from a stale dist/ and is missing the fixes from #414 and #415 — its contents are effectively v5.6.1. Upgrade to v5.7.0.'
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -6289,6 +6297,12 @@ snapshots:
     dependencies:
       hono: 4.12.31
 
+  '@hugeicons/core-free-icons@4.2.3': {}
+
+  '@hugeicons/react@1.1.9(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -7573,11 +7587,6 @@ snapshots:
 
   '@oxlint/binding-win32-x64-msvc@1.74.0':
     optional: true
-
-  '@phosphor-icons/react@2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
 
   '@pkgjs/parseargs@0.11.0':
     optional: true

--- a/typescript/dashboard/package.json
+++ b/typescript/dashboard/package.json
@@ -58,11 +58,12 @@
     "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "dependencies": {
+    "@hugeicons/core-free-icons": "^4.2.3",
+    "@hugeicons/react": "^1.1.9",
     "@mantine/charts": "^8.3.18",
     "@mantine/core": "^8.3.14",
     "@mantine/hooks": "^8.3.14",
     "@mantine/notifications": "^8.3.18",
-    "@phosphor-icons/react": "^2.1.10",
     "@workhorse/dashboard-server": "workspace:*",
     "recharts": "^3.10.1"
   },


### PR DESCRIPTION
Closes the icon-library migration in [WOR-221](https://linear.app/workhorse-run/issue/WOR-221/migrate-dashboard-icons-from-phosphor-to-hugeicons-free).

## What changed

`@phosphor-icons/react` is gone. The dashboard now draws Hugeicons free glyphs through one module, `dashboard/app/src/icons.tsx`.

That module is the only file in the dashboard that names an icon package. Screens import icons by what they mean to an operator — `CheckCircleIcon`, `HumanWaitIcon`, `QueuedIcon` — and choose a size by role rather than by pixel count.

## Why

Every screen used to import glyphs from the vendor directly, so the vendor's export names and its per-icon prop spelling reached into each screen file. Two consequences:

- Changing icon library meant editing 58 call sites. It is now one edit.
- A raw `size={16}` at each call site meant nothing forced two menu rows to agree on a measurement. Sizes are now named roles (`iconSize.menu`, `iconSize.control`, `iconSize.chip`), so the value lives in one place.

Emphasis moved the same way: the previous library's `weight` becomes a named stroke token, mapped once.

## Nothing about the screens changed

This is a library migration only. No layout, copy, or operator behaviour was touched. Each former pixel size maps to the token holding that identical value, so every icon renders at the size it did before.

## Screenshots

Both views run against the same demo backend at the same moment. The left column is `origin/main`, the right column is this branch. Only the glyphs change; every size, position, label, and colour is the same.

![Header controls, task sidebar, and the System health signal list, before and after](https://api.agent-drop.co/api/v1/assets/j57ew6g8zvhdrr2wx74zjzbz158cjc5j)

Read the sidebar rows top to bottom for the status set — `Blocked`, `Waiting`, `Scheduled`, `Retried`, `Queued`, `Running`, `Completed`, `Discarded`, `Canceled` — then the System health card for the operational set. `Retried` and `Discarded` are the two largest shape changes. `Canceled` moved from a filled prohibit sign to a plain cross.

The full task list, for context:

![All tasks page, before and after](https://api.agent-drop.co/api/v1/assets/j57b1rszstv5kjw07zej7gcp3x8ck9rp)

Both images are hosted externally and expire in 7 days.

## Icon mapping

| Meaning | Phosphor | Hugeicons free | Exported as |
| --- | --- | --- | --- |
| Success / completed | `CheckCircle` | `CheckmarkCircle02Icon` | `CheckCircleIcon` |
| Warning / blocked | `WarningCircle` | `Alert02Icon` | `WarningIcon` |
| Neutral explanation | `Info` | `InformationCircleIcon` | `InfoIcon` |
| Discarded | `XCircle` | `CancelCircleIcon` | `DiscardedIcon` |
| Cancelled / refused | `Prohibit` | `Cancel01Icon` | `ProhibitIcon` |
| Time / scheduled | `Clock` | `Clock01Icon` | `ClockIcon` |
| Recurring calendar | `CalendarDots` | `Calendar03Icon` | `CalendarIcon` |
| Copy to clipboard | `Copy` | `Copy01Icon` | `CopyIcon` |
| Row overflow menu | `DotsThreeVertical` | `MoreVerticalIcon` | `RowMenuIcon` |
| Filter / fallback action | `FunnelSimple` | `FilterIcon` | `FilterIconGlyph` |
| Settings | `GearSix` | `Settings02Icon` | `SettingsIcon` |
| Run / throughput | `Lightning` | `FlashIcon` | `LightningIcon` |
| Queued | `ListDashes` | `LeftToRightListDashIcon` | `QueuedIcon` |
| Task list | `ListChecks` | `CheckListIcon` | `TaskListIcon` |
| Search | `MagnifyingGlass` | `Search01Icon` | `SearchIcon` |
| Run now | `PlayCircle` | `PlayCircleIcon` | `PlayIcon` |
| Activity / health | `Pulse` | `Pulse01Icon` | `ActivityIcon` |
| Worker process | `Robot` | `Robot01Icon` | `WorkerIcon` |
| Human decision wait | `UserFocus` | `UserCheck01Icon` | `HumanWaitIcon` |
| Retry / retried | `ArrowCounterClockwise` | `ArrowTurnBackwardIcon` | `RetryIcon` |
| Refresh | `ArrowClockwise` | `RefreshIcon` | `RefreshIconGlyph` |
| Light theme | `Sun` | `Sun03Icon` | `LightThemeIcon` |
| Dark theme | `Moon` | `Moon02Icon` | `DarkThemeIcon` |
| Colour theme control | `Palette` | `PaintBoardIcon` | `ColorThemeIcon` |

Two substitutions are worth naming. Hugeicons free has no `Pulse`, so activity uses `Pulse01Icon`, the same cardiogram idea. Phosphor's `weight="fill"` has no stroke-based equivalent, so filled notification icons use the bold stroke; they read as emphasis in the same way.

`ColorThemeIcon` is deliberately not called `ThemeIcon`: Mantine exports a `ThemeIcon` container that several screens already import, and one name for two things would be a trap.

## Bundle

The main chunk got smaller, because only the used glyph data is pulled in.

| | Raw | Gzip |
| --- | --- | --- |
| Before | 1,142.94 kB | 335.27 kB |
| After | 1,095.07 kB | 326.02 kB |
| Delta | **−47.87 kB** | **−9.25 kB** |

## Verification

| Command | Result |
| --- | --- |
| `pnpm install` | pass |
| `pnpm --dir dashboard/app typecheck` | pass |
| `pnpm lint` | pass for changed files |
| `pnpm format:check` | pass for changed files |
| `pnpm --dir dashboard/app build` | pass |
| `vitest run dashboard/app/src/` | 25 files, 230 tests pass |
| `vitest run --config vitest.unit.config.ts` | 548 pass, 5 fail |
| `rg -n "@phosphor-icons/react"` | no matches, source and lockfile |

The 5 unit failures are pre-existing. Pristine `origin/main` fails the same 5 (`standalone-security` Unix socket, 4 demo telemetry). This branch adds 30 passing tests and introduces no new failure.

`pnpm lint` and `pnpm format:check` also report pre-existing problems in files this branch does not touch: `site-guide-coverage.test.ts`, `operator-read-sql.ts`, `feature-showcase.test.ts`, `docs/benchmarking.md`, `worker-suspension.test.ts`. All were confirmed on pristine `origin/main` and left alone.

## Known blocker, not caused by this branch

`pnpm build:runtime:dev` fails on macOS at `typescript/dashboard`'s GNU-style `sed -i`:

```
sed: 1: "dist/brand.js": extra characters at the end of d command
```

This is on `origin/main` and reproduces with a clean tree. It is the same defect as WOR-134/LEO-47, whose `sed -i.bak` fix is uncommitted in another checkout. The dashboard library output is well-formed — re-running the identical pipeline with the BSD-compatible form succeeds — so this blocks packaging, not this migration. Fixing it belongs to that issue, not this one.

## Residual risk

Glyph shapes differ slightly between the two libraries, so the icons look a little different even though every size and position is unchanged. The screenshots above show that difference on a running demo. A human should still confirm the result reads correctly at normal viewing distance.
