### PR TITLE
[WOR-235] Keep Bun from replacing the pnpm lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 docs/research
 node_modules/
+bun.lock
+bun.lockb
 dist/
 __pycache__/
 .mypy_cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,13 @@ Anything spawned outside those scripts still inherits the ambient environment. I
 test fails on a row count that looks slightly off, confirm which database the process actually
 resolved before concluding anything about the test.
 
+## Package installation and script runners
+
+pnpm owns dependency installation. Run `pnpm install`; a root preinstall guard rejects `bun install`
+and tells the developer to use pnpm. Bun and pnpm can both run repository scripts: use
+`bun run <script>` or `pnpm run <script>`. Those scripts call pnpm where the workspace filter or
+directory support needs it.
+
 ## One worktree, one branch, one commit
 
 A branch checked out anywhere is locked everywhere: `git checkout main` inside a linked worktree

--- a/docs/decisions/0033-pnpm-owns-dependency-installation.md
+++ b/docs/decisions/0033-pnpm-owns-dependency-installation.md
@@ -1,0 +1,46 @@
+# ADR 0033: Let pnpm own dependency installation
+
+- **Status:** Accepted
+- **Date:** 2026-08-16
+- **Related:** [ADR 0028](0028-flat-per-language-repository-layout.md)
+
+## Context
+
+Workhorse uses `pnpm-workspace.yaml`, pnpm workspace filters, and pnpm directory commands.
+Those commands define how the repository installs and runs its packages.
+
+Bun can run a package script, but `bun install` creates `bun.lock` and can migrate the pnpm lockfile.
+That changes the dependency layout without changing a product dependency.
+
+## Decision
+
+pnpm owns dependency installation. Developers run `pnpm install` to create `node_modules` and
+update `pnpm-lock.yaml`.
+
+The root `preinstall` script rejects a Bun package-manager user agent and names the required
+pnpm command. It is plain JavaScript run by `node`, because `preinstall` runs before any
+devDependency exists. The repository ignores `bun.lock` and `bun.lockb`, then a failed Bun attempt is
+removed before the next pnpm install.
+
+Bun and pnpm both run repository scripts. `bun run <script>` and `pnpm run <script>` are supported.
+Scripts retain their pnpm workspace commands so each command keeps its existing package selection.
+
+## Consequences
+
+- A Bun install fails with a command that tells the developer to run `pnpm install`.
+- A pnpm install remains the only operation that changes the tracked lockfile.
+- A developer can use Bun as a script runner without changing the package manager.
+- A future change that makes Bun own installation must replace the pnpm workspace commands and
+  record a new decision.
+
+## Rejected alternatives
+
+### Let either package manager install dependencies
+
+The package managers use different lockfiles and installation layouts. Allowing both makes a
+routine local install change the repository state unexpectedly.
+
+### Allow Bun installs and ignore its lockfile
+
+Ignoring the lockfile hides the change but does not stop Bun from replacing the dependency layout.
+The next pnpm install still needs to repair it.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "preinstall": "node scripts/require-pnpm.mjs",
     "dev": "pnpm demo",
     "build": "pnpm build:runtime && pnpm docs:build && pnpm --filter @workhorse/demo build && pnpm python:build",
     "build:runtime": "tsx scripts/build-runtime.ts",
@@ -88,11 +89,5 @@
     "typescript": "^5.8.3",
     "vitest": "^3.2.4"
   },
-  "packageManager": "pnpm@10.18.3",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "lefthook",
-      "sharp"
-    ]
-  }
+  "packageManager": "pnpm@10.18.3"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
 
 onlyBuiltDependencies:
   - lefthook
+  - sharp

--- a/scripts/require-pnpm.mjs
+++ b/scripts/require-pnpm.mjs
@@ -1,0 +1,24 @@
+// The installation guard runs as `preinstall`, before any dependency exists. It is plain
+// JavaScript and imports nothing, because `tsx` and every other devDependency is still absent at
+// that point — a guard that needed one would fail the very command it tells the developer to run.
+
+const message =
+  "Workhorse uses pnpm for dependency installation. Run pnpm install instead of bun install.";
+
+/**
+ * True when a package manager identifies itself as Bun.
+ *
+ * npm, pnpm, and Bun all publish `npm_config_user_agent` in the form `name/version ...`, so the
+ * first field identifies the caller.
+ *
+ * @param {string | undefined} userAgent
+ * @returns {boolean}
+ */
+export function isBunUserAgent(userAgent) {
+  return userAgent === undefined ? false : userAgent.split(" ")[0].startsWith("bun/");
+}
+
+if (isBunUserAgent(process.env.npm_config_user_agent)) {
+  console.error(message);
+  process.exit(1);
+}

--- a/scripts/require-pnpm.test.ts
+++ b/scripts/require-pnpm.test.ts
@@ -1,0 +1,42 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const guard = path.join(path.dirname(fileURLToPath(import.meta.url)), "require-pnpm.mjs");
+
+/**
+ * Run the guard exactly as `preinstall` runs it: `node`, no dependency, one environment variable.
+ *
+ * The test drives the real entry point rather than an exported helper, because the failure this
+ * guard prevents is a package manager reaching the install, not a predicate returning false.
+ */
+function runGuard(userAgent: string | undefined): { status: number | null; stderr: string } {
+  const result = spawnSync(process.execPath, [guard], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...(userAgent === undefined ? {} : { npm_config_user_agent: userAgent }),
+    },
+  });
+  return { status: result.status, stderr: result.stderr };
+}
+
+describe("the package manager installation guard", () => {
+  it("rejects a Bun install before it can replace the pnpm lockfile", () => {
+    const result = runGuard("bun/1.3.14 npm/? node/v26.5.0 darwin arm64");
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Run pnpm install instead of bun install");
+  });
+
+  it("allows a pnpm install", () => {
+    const result = runGuard("pnpm/10.18.3 npm/? node/v24.13.3 darwin arm64");
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+
+  it("allows an install that publishes no package manager user agent", () => {
+    const result = runGuard(undefined);
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
https://linear.app/workhorse-run/issue/WOR-235/make-bun-and-pnpm-coexist-without-breaking-the-lockfile

## Why

A plain `bun install` in this repository migrated `pnpm-lock.yaml` into a new `bun.lock` and rebuilt `node_modules` in Bun layout. The repository declares `packageManager: pnpm@10.18.3`, and every script uses `pnpm --filter` or `pnpm --dir`. Recovery needed `rm -f bun.lock`, deleting every `node_modules`, and `pnpm install`.

## What changed

- A root `preinstall` guard rejects a Bun package-manager user agent and names `pnpm install`. It is plain JavaScript run by `node`: `preinstall` runs before any devDependency exists, so a guard that needed `tsx` would fail the very command it recommends.
- `.gitignore` covers `bun.lock` and `bun.lockb`.
- `onlyBuiltDependencies` moves to `pnpm-workspace.yaml`, where pnpm 10 reads it. The `pnpm` field in `package.json` was ignored, and pnpm printed a warning on every command.
- ADR 0033 records that pnpm owns installation and that either runner may run scripts. `AGENTS.md` says the same for agents.

## Testing

- `pnpm typecheck` and `pnpm format:check` pass. `oxlint` is clean over `scripts/`.
- `pnpm test`: 1022 passed. The failures are exactly the set a clean `origin/main` worktree produces, one of which needs `pg_dump`, which is not installed on this machine.
- The guard itself: a Bun user agent exits 1 with the message, a pnpm user agent and an absent user agent exit 0. The test spawns the real entry point rather than importing a predicate.

## Notes

`pnpm lint` inherits five pre-existing errors from `main`, tracked in WOR-241.