### PR TITLE
[WOR-244] Constrain job payload and result types to JSON

### DIFF
--- a/typescript/core/benchmarks/comparative.ts
+++ b/typescript/core/benchmarks/comparative.ts
@@ -486,8 +486,7 @@ function createAdapters(pool: Pool, options: ComparativeBenchmarkOptions): Queue
       schema: "workhorse",
       enqueueMany: (requests) => queue.enqueueMany(requests),
       claim: (workerId) => queue.claim(workerId, { leaseMs: options.leaseMs }),
-      complete: (job, workerId) =>
-        queue.complete(job as ClaimedJob<unknown>, workerId, { ok: true }),
+      complete: (job, workerId) => queue.complete(job as ClaimedJob, workerId, { ok: true }),
       claimSql: "SELECT * FROM workhorse.claim_v2($1, $2, $3)",
     },
   ];

--- a/typescript/core/src/queue.ts
+++ b/typescript/core/src/queue.ts
@@ -576,7 +576,7 @@ export class Queue {
     return this.modules.operatorReads.getChildLineage(jobId, limit);
   }
 
-  async claim<TPayload = Json>(
+  async claim<TPayload extends Json = Json>(
     workerId: string,
     options: { queue?: string; leaseMs?: number } = {},
   ): Promise<ClaimedJob<TPayload> | null> {
@@ -593,23 +593,23 @@ export class Queue {
     return this.modules.claimLeaseFence.recordBatchFailure(batch);
   }
 
-  async heartbeat(job: ClaimedJob<unknown>, workerId: string, leaseMs = 30_000): Promise<boolean> {
+  async heartbeat(job: ClaimedJob, workerId: string, leaseMs = 30_000): Promise<boolean> {
     return this.modules.claimLeaseFence.heartbeat(job, workerId, leaseMs);
   }
 
   async heartbeatStatus(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     leaseMs = 30_000,
   ): Promise<HeartbeatStatus> {
     return this.modules.claimLeaseFence.heartbeatStatus(job, workerId, leaseMs);
   }
 
-  async expireOwned(job: ClaimedJob<unknown>, workerId: string): Promise<ExpireOwnedStatus> {
+  async expireOwned(job: ClaimedJob, workerId: string): Promise<ExpireOwnedStatus> {
     return this.modules.claimLeaseFence.expireOwned(job, workerId);
   }
 
-  async acknowledgeCancel(job: ClaimedJob<unknown>, workerId: string): Promise<boolean> {
+  async acknowledgeCancel(job: ClaimedJob, workerId: string): Promise<boolean> {
     return this.modules.claimLeaseFence.acknowledgeCancel(job, workerId);
   }
 
@@ -627,7 +627,7 @@ export class Queue {
   }
 
   async saveCheckpoint<TValue extends Json>(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     name: string,
     value: TValue,
@@ -642,7 +642,7 @@ export class Queue {
   }
 
   async updateProgress<TValue extends Json>(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     value: TValue,
   ): Promise<JobProgress<TValue>> {
@@ -658,7 +658,7 @@ export class Queue {
   }
 
   async scheduleWait(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     name: string,
     request: ScheduleWaitRequest,
@@ -667,7 +667,7 @@ export class Queue {
   }
 
   async waitForSignal<TPayload extends Json = Json>(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     name: string,
     options: ExternalWaitOptions = {},
@@ -689,7 +689,7 @@ export class Queue {
   }
 
   async waitForHuman<TContext extends Json, TResult extends Json = Json>(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     name: string,
     context: TContext,
@@ -720,7 +720,7 @@ export class Queue {
   }
 
   async createChild<TPayload extends Json, TResult extends Json = Json>(
-    parent: ClaimedJob<unknown>,
+    parent: ClaimedJob,
     workerId: string,
     name: string,
     type: string,
@@ -731,7 +731,7 @@ export class Queue {
   }
 
   async createChildren<TResult extends Record<string, Json> = Record<string, Json>>(
-    parent: ClaimedJob<unknown>,
+    parent: ClaimedJob,
     workerId: string,
     children: readonly ChildJobRequest[],
   ): Promise<CreateChildrenResult<TResult>> {
@@ -739,7 +739,7 @@ export class Queue {
   }
 
   async complete<TResult extends Json>(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     result: TResult,
   ): Promise<boolean> {
@@ -749,7 +749,7 @@ export class Queue {
   }
 
   async fail(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     error: unknown,
     retryDelayMs?: number,
@@ -769,7 +769,7 @@ export class Queue {
     return this.modules.claimLeaseFence.recoverExpired(limit, retryDelayMs);
   }
 
-  async getJob<TResult = Json>(id: string): Promise<JobSnapshot<TResult> | null> {
+  async getJob<TResult extends Json = Json>(id: string): Promise<JobSnapshot<TResult> | null> {
     return this.modules.operatorReads.getJob<TResult>(id);
   }
 

--- a/typescript/core/src/queue/checkpoints-progress-waits.ts
+++ b/typescript/core/src/queue/checkpoints-progress-waits.ts
@@ -205,7 +205,7 @@ export class CheckpointsProgressWaitsModule extends QueueModule {
   }
 
   async saveCheckpoint<TValue extends Json>(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     name: string,
     value: TValue,
@@ -249,7 +249,7 @@ export class CheckpointsProgressWaitsModule extends QueueModule {
   }
 
   async updateProgress<TValue extends Json>(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     value: TValue,
   ): Promise<JobProgress<TValue>> {
@@ -305,7 +305,7 @@ export class CheckpointsProgressWaitsModule extends QueueModule {
   }
 
   async scheduleWait(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     name: string,
     request: ScheduleWaitRequest,

--- a/typescript/core/src/queue/child-jobs.ts
+++ b/typescript/core/src/queue/child-jobs.ts
@@ -109,7 +109,7 @@ export class ChildJobsModule extends QueueModule {
   }
 
   private childRequest<TPayload extends Json>(
-    parent: ClaimedJob<unknown>,
+    parent: ClaimedJob,
     type: string,
     payload: TPayload,
     options: ChildJobOptions,
@@ -145,7 +145,7 @@ export class ChildJobsModule extends QueueModule {
   }
 
   async createChild<TPayload extends Json, TResult extends Json = Json>(
-    parent: ClaimedJob<unknown>,
+    parent: ClaimedJob,
     workerId: string,
     name: string,
     type: string,
@@ -179,7 +179,7 @@ export class ChildJobsModule extends QueueModule {
   }
 
   async createChildren<TResult extends Record<string, Json> = Record<string, Json>>(
-    parent: ClaimedJob<unknown>,
+    parent: ClaimedJob,
     workerId: string,
     children: readonly ChildJobRequest[],
   ): Promise<CreateChildrenResult<TResult>> {

--- a/typescript/core/src/queue/claim-lease-fence.ts
+++ b/typescript/core/src/queue/claim-lease-fence.ts
@@ -73,7 +73,7 @@ export type FailureStatus =
 class FencedLease {
   private constructor(readonly sqlParameters: readonly [string, string, string]) {}
 
-  static from(job: ClaimedJob<unknown>, workerId: string): FencedLease {
+  static from(job: ClaimedJob, workerId: string): FencedLease {
     return new FencedLease([job.id, workerId, job.fenceToken.toString()]);
   }
 }
@@ -159,7 +159,7 @@ export class ClaimLeaseFenceModule extends QueueModule {
     };
   }
 
-  async claim<TPayload = Json>(
+  async claim<TPayload extends Json = Json>(
     workerId: string,
     options: { queue?: string; leaseMs?: number } = {},
   ): Promise<ClaimedJob<TPayload> | null> {
@@ -254,12 +254,12 @@ export class ClaimLeaseFenceModule extends QueueModule {
     this.assertBatchRecorded(result, "record_batch_failure_v1", batch.jobs.length);
   }
 
-  async heartbeat(job: ClaimedJob<unknown>, workerId: string, leaseMs = 30_000): Promise<boolean> {
+  async heartbeat(job: ClaimedJob, workerId: string, leaseMs = 30_000): Promise<boolean> {
     return (await this.heartbeatStatus(job, workerId, leaseMs)) === "accepted";
   }
 
   async heartbeatStatus(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     leaseMs = 30_000,
   ): Promise<HeartbeatStatus> {
@@ -290,7 +290,7 @@ export class ClaimLeaseFenceModule extends QueueModule {
     });
   }
 
-  async expireOwned(job: ClaimedJob<unknown>, workerId: string): Promise<ExpireOwnedStatus> {
+  async expireOwned(job: ClaimedJob, workerId: string): Promise<ExpireOwnedStatus> {
     const lease = FencedLease.from(job, workerId);
     const result = await this.context.database.query<{
       status: ExpireOwnedStatus;
@@ -314,7 +314,7 @@ export class ClaimLeaseFenceModule extends QueueModule {
     return expiration.status;
   }
 
-  async acknowledgeCancel(job: ClaimedJob<unknown>, workerId: string): Promise<boolean> {
+  async acknowledgeCancel(job: ClaimedJob, workerId: string): Promise<boolean> {
     const lease = FencedLease.from(job, workerId);
     const result = await this.context.database.query<{ accepted: boolean }>(
       "SELECT workhorse.acknowledge_cancel_v1($1::uuid, $2::text, $3::bigint) AS accepted",
@@ -330,7 +330,7 @@ export class ClaimLeaseFenceModule extends QueueModule {
   }
 
   async complete<TResult extends Json>(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     result: TResult,
     validateResult: () => void,
@@ -361,7 +361,7 @@ export class ClaimLeaseFenceModule extends QueueModule {
   }
 
   async fail(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     error: unknown,
     retryDelayMs?: number,

--- a/typescript/core/src/queue/enqueue-contracts.ts
+++ b/typescript/core/src/queue/enqueue-contracts.ts
@@ -467,7 +467,7 @@ export class EnqueueContractsModule extends QueueModule {
     };
   }
 
-  validateResult(job: ClaimedJob<unknown>, result: Json): void {
+  validateResult(job: ClaimedJob, result: Json): void {
     if (job.contractVersion !== null) {
       const contract = this.context.options.contracts?.[job.type]?.versions[job.contractVersion];
       if (contract === undefined) {

--- a/typescript/core/src/queue/human-waits.ts
+++ b/typescript/core/src/queue/human-waits.ts
@@ -139,7 +139,7 @@ export class HumanWaitsModule extends QueueModule {
   }
 
   async waitForHuman<TContext extends Json, TResult extends Json = Json>(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     name: string,
     context: TContext,

--- a/typescript/core/src/queue/operator-reads.ts
+++ b/typescript/core/src/queue/operator-reads.ts
@@ -895,7 +895,7 @@ export class OperatorReadsModule extends QueueModule {
     };
   }
 
-  async getJob<TResult = Json>(id: string): Promise<JobSnapshot<TResult> | null> {
+  async getJob<TResult extends Json = Json>(id: string): Promise<JobSnapshot<TResult> | null> {
     // A job exists in exactly one lifecycle relation: runtime while live, outcome when terminal.
     const result = await this.context.database.query<{
       id: string;

--- a/typescript/core/src/queue/signals.ts
+++ b/typescript/core/src/queue/signals.ts
@@ -127,7 +127,7 @@ export class SignalsModule extends QueueModule {
   }
 
   async waitForSignal<TPayload extends Json = Json>(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     name: string,
     options: ExternalWaitOptions = {},

--- a/typescript/core/src/telemetry.ts
+++ b/typescript/core/src/telemetry.ts
@@ -358,9 +358,7 @@ export function recordHeartbeatFailure(status: Exclude<HeartbeatStatus, "accepte
   telemetryMetrics.heartbeatFailures.add(1, { "workhorse.heartbeat.status": status });
 }
 
-export function jobSpanAttributes(
-  job: Pick<ClaimedJob<unknown>, "id" | "type" | "attempt">,
-): Attributes {
+export function jobSpanAttributes(job: Pick<ClaimedJob, "id" | "type" | "attempt">): Attributes {
   return {
     "workhorse.job.id": job.id,
     "workhorse.job.type": job.type,
@@ -368,7 +366,7 @@ export function jobSpanAttributes(
   };
 }
 
-export function jobMetricAttributes(job: Pick<ClaimedJob<unknown>, "queue" | "type">): Attributes {
+export function jobMetricAttributes(job: Pick<ClaimedJob, "queue" | "type">): Attributes {
   return {
     "workhorse.queue.name": job.queue,
     "workhorse.job.type": job.type,

--- a/typescript/core/src/types.ts
+++ b/typescript/core/src/types.ts
@@ -700,7 +700,7 @@ export interface ChildLineage {
   truncated: boolean;
 }
 
-export interface ClaimedJob<TPayload = Json> {
+export interface ClaimedJob<TPayload extends Json = Json> {
   /** Stable job identity across all attempts. */
   id: string;
   /** Queue from which PostgreSQL granted this attempt. */
@@ -736,7 +736,7 @@ export interface ClaimedJob<TPayload = Json> {
 /** Ordered claims that one worker coordinator delivers to a shared batch callback. */
 export interface BatchExecutionRecord {
   batchId: string;
-  jobs: readonly ClaimedJob<unknown>[];
+  jobs: readonly ClaimedJob[];
   workerId: string;
 }
 
@@ -796,7 +796,7 @@ export type JobState =
   | "failed"
   | "canceled";
 
-export interface JobSnapshot<TResult = Json> {
+export interface JobSnapshot<TResult extends Json = Json> {
   id: string;
   queue: string;
   type: string;

--- a/typescript/core/src/worker.ts
+++ b/typescript/core/src/worker.ts
@@ -89,7 +89,7 @@ export type Failpoint =
   | "afterHandler"
   | "beforeComplete"
   | "afterComplete";
-export interface HandlerContext<TPayload = Json> {
+export interface HandlerContext<TPayload extends Json = Json> {
   job: ClaimedJob<TPayload>;
   signal: AbortSignal;
   /** Read a previously persisted restart boundary without executing user code. */
@@ -136,19 +136,19 @@ export interface HandlerContext<TPayload = Json> {
   ): Promise<TResult>;
 }
 
-export type Handler<TPayload = Json, TResult extends Json = Json> = (
+export type Handler<TPayload extends Json = Json, TResult extends Json = Json> = (
   payload: TPayload,
   context: HandlerContext<TPayload>,
 ) => Promise<TResult> | TResult;
 
 /** Per-job batch context without APIs that suspend and replay an individual handler. */
-export type BatchHandlerContext<TPayload = Json> = Omit<
+export type BatchHandlerContext<TPayload extends Json = Json> = Omit<
   HandlerContext<TPayload>,
   "sleep" | "sleepUntil" | "waitForSignal" | "waitForHuman" | "runChild" | "runChildren"
 >;
 
 /** One independently leased job delivered to a shared batch-handler invocation. */
-export interface BatchHandlerItem<TPayload = Json> {
+export interface BatchHandlerItem<TPayload extends Json = Json> {
   payload: TPayload;
   context: BatchHandlerContext<TPayload>;
 }
@@ -162,7 +162,7 @@ export type BatchHandlerOutcome<TResult extends Json = Json> =
  * A compatible group of jobs from one queue and job type. Outcomes correspond by array position;
  * throwing or returning an invalid outcome list fails every member through its own fenced lifecycle.
  */
-export type BatchHandler<TPayload = Json, TResult extends Json = Json> = (
+export type BatchHandler<TPayload extends Json = Json, TResult extends Json = Json> = (
   items: readonly BatchHandlerItem<TPayload>[],
 ) => Promise<readonly BatchHandlerOutcome<TResult>[]> | readonly BatchHandlerOutcome<TResult>[];
 
@@ -203,48 +203,44 @@ export interface WorkerQueueApi {
   ): Promise<ClaimedJob | null>;
   recordBatchDispatch?(batch: BatchExecutionRecord): Promise<void>;
   recordBatchFailure?(batch: BatchExecutionRecord): Promise<void>;
-  heartbeatStatus(
-    job: ClaimedJob<unknown>,
-    workerId: string,
-    leaseMs?: number,
-  ): Promise<HeartbeatStatus>;
-  expireOwned(job: ClaimedJob<unknown>, workerId: string): Promise<ExpireOwnedStatus>;
-  acknowledgeCancel(job: ClaimedJob<unknown>, workerId: string): Promise<boolean>;
+  heartbeatStatus(job: ClaimedJob, workerId: string, leaseMs?: number): Promise<HeartbeatStatus>;
+  expireOwned(job: ClaimedJob, workerId: string): Promise<ExpireOwnedStatus>;
+  acknowledgeCancel(job: ClaimedJob, workerId: string): Promise<boolean>;
   listCheckpoints(jobId: string): Promise<JobCheckpoint[]>;
   saveCheckpoint<TValue extends Json>(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     name: string,
     value: TValue,
   ): Promise<JobCheckpoint<TValue>>;
   getProgress(jobId: string): Promise<JobProgress | null>;
   updateProgress<TValue extends Json>(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     value: TValue,
   ): Promise<JobProgress<TValue>>;
   listWaits(jobId: string): Promise<JobWait[]>;
   scheduleWait(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     name: string,
     request: ScheduleWaitRequest,
   ): Promise<ScheduleWaitResult>;
   waitForSignal<TPayload extends Json = Json>(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     name: string,
     options?: ExternalWaitOptions,
   ): Promise<WaitForSignalResult<TPayload>>;
   waitForHuman<TContext extends Json, TResult extends Json = Json>(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     name: string,
     context: TContext,
     options?: ExternalWaitOptions,
   ): Promise<import("./queue/human-waits.js").WaitForHumanResult<TResult>>;
   createChild<TPayload extends Json, TResult extends Json = Json>(
-    parent: ClaimedJob<unknown>,
+    parent: ClaimedJob,
     workerId: string,
     name: string,
     type: string,
@@ -252,17 +248,17 @@ export interface WorkerQueueApi {
     options?: ChildJobOptions,
   ): Promise<CreateChildResult<TResult>>;
   createChildren<TResult extends Record<string, Json> = Record<string, Json>>(
-    parent: ClaimedJob<unknown>,
+    parent: ClaimedJob,
     workerId: string,
     children: readonly ChildJobRequest[],
   ): Promise<CreateChildrenResult<TResult>>;
   complete<TResult extends Json>(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     result: TResult,
   ): Promise<boolean>;
   fail(
-    job: ClaimedJob<unknown>,
+    job: ClaimedJob,
     workerId: string,
     error: unknown,
     retryDelayMs?: number,

--- a/typescript/core/test/public-type-contracts.test.ts
+++ b/typescript/core/test/public-type-contracts.test.ts
@@ -1,0 +1,15 @@
+import { expectTypeOf, it } from "vitest";
+import type { ClaimedJob, JobSnapshot, Queue } from "../src/index.js";
+
+function assertNonJsonTypeArgumentsFail(queue: Queue): void {
+  // @ts-expect-error Date cannot be stored in a JSON payload column.
+  void queue.claim<Date>("worker");
+  // @ts-expect-error Date cannot be stored in a JSON result column.
+  void queue.getJob<Date>("job");
+}
+
+it("constrains claimed payloads and snapshot results to JSON", () => {
+  expectTypeOf<Awaited<ReturnType<Queue["claim"]>>>().toEqualTypeOf<ClaimedJob | null>();
+  expectTypeOf<Awaited<ReturnType<Queue["getJob"]>>>().toEqualTypeOf<JobSnapshot | null>();
+  expectTypeOf(assertNonJsonTypeArgumentsFail).toBeFunction();
+});


### PR DESCRIPTION
## Defect

`ClaimedJob<TPayload>` and `JobSnapshot<TResult>` accepted unconstrained type arguments. Calls such as `queue.claim<Date>()` and `queue.getJob<Date>()` compiled even though PostgreSQL returns JSON values, which could cause runtime method errors.

The same gap existed on the exported handler payload types.

## Fix

- Constrain claimed payload and snapshot result types to `Json`.
- Constrain the public `Queue` methods and exported handler payload types to the same contract.
- Replace payload-agnostic `ClaimedJob<unknown>` uses with the JSON-defaulted `ClaimedJob` type.
- Add negative type assertions for `queue.claim<Date>()` and `queue.getJob<Date>()`.

## Verification

- `pnpm typecheck` — passed across the TypeScript workspace, dashboard, site, and Python type checks.
- Pre-commit changed unit scope — 19 files passed, 203 tests passed.
- `pnpm test:unit -- typescript/core/test/public-type-contracts.test.ts` — 76 files passed, 563 tests passed. The new type-contract test passed.
- `pnpm test` — 91 files passed and 1,018 tests passed; 9 unrelated existing environment/timing failures remained. One failure is `spawn pg_dump ENOENT`. Eight failures are database-clock/timing assertions in durable waits, deadlines, dependency scheduling, retry timing, and retention cleanup. The type-contract test passed in this run.
- Changed-file Oxlint and Oxfmt checks — passed.

Linear: https://linear.app/workhorse-run/issue/WOR-244/constrain-claimedjob-and-jobsnapshot-generics-to-json
