### PR TITLE
[WOR-243] Guarantee worker cleanup and observe expiration failures

### DIFF
--- a/typescript/core/src/worker.ts
+++ b/typescript/core/src/worker.ts
@@ -973,17 +973,22 @@ export class Worker {
       });
       return expirationPromise;
     };
+    const expireOwnershipInBackground = (): void => {
+      // Observe the memoized promise without replacing it: the settlement path still awaits the
+      // original rejection, while a handler that ignores abort cannot cause an unhandled rejection.
+      void expireOwnership().catch((error: unknown) => controller.abort(error));
+    };
     const refreshOwnership = async () => {
       const status = await this.queue.heartbeatStatus(job, this.workerId, this.leaseMs);
       if (status === "cancel_requested") {
         markCancellationRequested();
       } else if (status === "deadline_exceeded") {
         stopHeartbeat();
-        void expireOwnership();
+        expireOwnershipInBackground();
         if (!controller.signal.aborted) controller.abort(new DeadlineExceededError(job.id));
       } else if (status === "timeout_exceeded") {
         stopHeartbeat();
-        void expireOwnership();
+        expireOwnershipInBackground();
         if (!controller.signal.aborted)
           controller.abort(new ExecutionTimeoutError(job.id, job.attempt));
       } else if (status === "stale") {
@@ -1012,7 +1017,7 @@ export class Worker {
               controller.abort(new ExecutionTimeoutError(job.id, job.attempt));
           }
           stopHeartbeat();
-          void expireOwnership();
+          expireOwnershipInBackground();
         },
         // The extra millisecond keeps the timer from leading the database clock: expirationAt was
         // truncated to milliseconds on the way to the client, so firing at it exactly can precede
@@ -1669,8 +1674,11 @@ export class Worker {
     } finally {
       this.running = false;
       this.draining = this.activeSlots > 0;
-      await notificationSubscription?.close();
-      await this.deregister();
+      try {
+        await notificationSubscription?.close();
+      } finally {
+        await this.deregister();
+      }
       logInfo("workhorse.worker.stopped", "Worker stopped", {
         "workhorse.queue.name": this.queueName,
         "workhorse.worker.id": this.workerId,

--- a/typescript/core/test/integration-claim-lease-fence.test.ts
+++ b/typescript/core/test/integration-claim-lease-fence.test.ts
@@ -690,6 +690,50 @@ describe("claim lease fence", () => {
     });
   });
 
+  it("observes a timer-driven expiration rejection while the handler ignores abort", async () => {
+    const expirationStarted = deferred();
+    const releaseHandler = deferred();
+    const expirationFailure = new Error("expiration connection lost");
+    const unhandledRejections: unknown[] = [];
+    const recordUnhandledRejection = (reason: unknown): void => {
+      unhandledRejections.push(reason);
+    };
+    const rejectingQueue = new Proxy(queue, {
+      get(target, property, receiver) {
+        if (property === "expireOwned") {
+          return async () => {
+            expirationStarted.resolve();
+            throw expirationFailure;
+          };
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    await queue.enqueue("expiration-rejection", null, { executionTimeoutMs: 50 });
+    const worker = new Worker(rejectingQueue, {
+      workerId: "expiration-rejection-worker",
+      leaseMs: 5_000,
+      heartbeatMs: 1_000,
+    }).handle("expiration-rejection", async () => {
+      await releaseHandler.promise;
+      return null;
+    });
+
+    process.on("unhandledRejection", recordUnhandledRejection);
+    const execution = worker.runOnce();
+    try {
+      await expirationStarted.promise;
+      await sleep(0);
+      expect(unhandledRejections).toEqual([]);
+      releaseHandler.resolve();
+      await expect(execution).rejects.toBe(expirationFailure);
+    } finally {
+      releaseHandler.resolve();
+      await execution.catch(() => undefined);
+      process.off("unhandledRejection", recordUnhandledRejection);
+    }
+  });
+
   it("keeps lease recovery authoritative when it wins an attempt-timeout race", async () => {
     const expirationStarted = deferred();
     const releaseExpiration = deferred();

--- a/typescript/core/test/integration-worker-registry.test.ts
+++ b/typescript/core/test/integration-worker-registry.test.ts
@@ -40,6 +40,37 @@ describe("worker registry", () => {
     await expect(registration()).resolves.toBeUndefined();
   });
 
+  it("deregisters when notification subscription cleanup fails", async () => {
+    const closeFailure = new Error("notification close failed");
+    const close = vi.fn<() => Promise<void>>(async () => {
+      throw closeFailure;
+    });
+    const subscribe = vi.spyOn(queue, "subscribeToJobNotifications").mockResolvedValue({ close });
+    const worker = new Worker(queue, {
+      workerId: "registry-notification-close-failure",
+      queue: "default",
+      pollMs: 10,
+      registryIntervalMs: 100,
+    }).handle("registry-notification-close-failure", () => null);
+    const registration = async () =>
+      (await queue.listWorkers()).find(
+        (entry) => entry.workerId === "registry-notification-close-failure",
+      );
+
+    try {
+      const running = worker.run();
+      await vi.waitFor(async () => expect(await registration()).toBeDefined());
+      await vi.waitFor(() => expect(subscribe).toHaveBeenCalledOnce());
+
+      worker.stop();
+      await expect(running).rejects.toBe(closeFailure);
+      expect(close).toHaveBeenCalledOnce();
+      await expect(registration()).resolves.toBeUndefined();
+    } finally {
+      subscribe.mockRestore();
+    }
+  });
+
   it("applies an operator pause written to PostgreSQL by another process", async () => {
     // The pause is written through a separate Queue instance holding no reference to the worker
     // object, which is exactly the situation of a dashboard running outside the worker process.


### PR DESCRIPTION
## Defect

Worker shutdown awaited notification cleanup before deregistration. A rejected subscription `close()` therefore left the worker registered until registry expiry. Timer-driven ownership expiration also started the memoized `expireOwned` promise without a rejection observer, so a handler that ignored abort could trigger an unhandled rejection.

## Fix

- Deregister in a `finally` block after notification cleanup, while preserving the close rejection for the caller.
- Route all background ownership expiration calls through one helper that observes rejection and aborts the handler context.
- Keep the original memoized expiration promise unchanged so the settlement path can still await and surface its rejection.
- Add real-PostgreSQL regression coverage for both failure paths.

## Verification

```text
pnpm typecheck
Success: no issues found in TypeScript packages, dashboard, site, scripts, or Python.

vitest integration-worker-registry + integration-claim-lease-fence
Test Files  2 passed (2)
Tests       79 passed (79)

pre-commit changed unit scope
Test Files  17 passed (17)
Tests       197 passed (197)

pnpm test
Test Files  8 failed | 90 passed (98)
Tests       9 failed | 1019 passed (1028)
```

The full suite failures are outside this diff. Seven are existing timing-sensitive database assertions. One requires `pg_dump`, which is not installed in the local environment. Both changed integration files passed in the full run, including all 79 tests and both new regressions.

Targeted Oxlint and Oxfmt checks passed for all three changed files. Root lint remains blocked by five existing errors in unrelated files.

Linear: https://linear.app/workhorse-run/issue/WOR-243/worker-shutdown-skips-deregistration-and-can-raise-an-unhandled
