### PR TITLE
[WH-11] Prepare Ontrack tracker switch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,53 @@
 
 Instructions for coding agents and contributors.
 
+## Work from production Ontrack
+
+All repository work lives in the production Ontrack `Workhorse` Project (`WH`). Connect over
+pgwire with `ONTRACK_AGENT_DSN` from this checkout's ignored `.env`; the Board is hosted at
+`https://ontrack.sh` and is never a local process. If the hosted Board is unreachable, stop and tell
+the Human. A local Ontrack database contains no authoritative Workhorse Issues.
+
+The machine's Private Token lives once in `~/.pgpass`, whose mode must be `0600`. The DSN carries no
+password, requires `sslmode=require`, and uses its username only as this checkout's Agent Session
+name. The secret resolves the host Agent; the Session separates simultaneous checkouts. Never put a
+secret in `.env`, a command, a Comment, or Git.
+
+This checkout's `.env` must contain `ONTRACK_AGENT_DSN` explicitly. Never inherit another
+checkout's ambient value. A linked worktree gets the host DSN from its primary checkout, strips any
+password, and rewrites the username to its worktree ID. If the key is absent, configure it in the
+primary checkout and rerun that repository's worktree setup; do not copy another worktree's DSN or
+mint another Agent.
+
+Before changing tracked files:
+
+1. Load this checkout's `.env` and connect with a PostgreSQL client. Require the DSN to be
+   passwordless, TLS-required, and named for this checkout.
+2. Read the target `WH-*` Issue, its Comments, and both ends of its Relations. Read the repository's
+   `CONTEXT.md` and relevant decision records when the work changes domain behavior.
+3. Claim that exact Issue with `app.claim_issue('WH-123')`. Work only Issues this Session holds.
+
+The host Agent may see other Ontrack Projects, so every Board read must filter
+`project_key = 'WH'`, every new Issue must pass `project_key => 'WH'`, and every mutation must name
+an exact `WH-*` key. Never use `app.claim_next()`: it is not Project-scoped and can claim another
+repository's work. To choose work, query eligible Workhorse Issues first and then claim the chosen
+key explicitly.
+
+An imported Issue's Ontrack `WH-*` key is its current working identity. Its `Plane provenance`
+section and source UUID preserve the historical Plane key. In Git history, `WH-*` subjects before
+the tracker cutover commit mean Plane keys; later subjects mean native Ontrack keys. Use
+`docs/tracker-history.md` and imported provenance to cross that boundary.
+
+Keep the Board current while working. Renew the Lease at least every two minutes with
+`app.renew_lease('WH-123')`, and add Comments for material decisions, scope changes, and verification
+evidence with `app.add_comment`. A live Lease means In Progress; do not set that Status directly.
+
+Finish only after every acceptance item is verified and the relevant repository checks pass. Add a
+Comment with the exact evidence, update the Issue checklist, and set it to Done in the same task.
+When another Agent can continue the current work as-is, Comment the handoff and move it to Todo.
+When a Human decision or action is required, Comment the boundary and move it to Backlog at that
+moment. Do not leave a live Lease behind while waiting.
+
 ## Do not run the demo server
 
 Do not start the demo. Not `pnpm demo`, not `pnpm demo:app`, and not a variant in the background.

--- a/docs/decisions/0041-apache-2-and-contributor-agreement.md
+++ b/docs/decisions/0041-apache-2-and-contributor-agreement.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** 2026-08-25
-- **Related:** [WH-434](https://app.plane.so/techprogress/browse/WH-434/)
+- **Related:** [Plane WH-434](https://ontrack.sh/projects/WH/issues/WH-281)
 
 ## Context
 

--- a/docs/decisions/0042-publish-the-first-public-beta.md
+++ b/docs/decisions/0042-publish-the-first-public-beta.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** 2026-08-25
-- **Related:** [WH-435](https://app.plane.so/techprogress/browse/WH-435/)
+- **Related:** [Plane WH-435](https://ontrack.sh/projects/WH/issues/WH-88)
 
 ## Context
 

--- a/docs/decisions/0043-public-ci-and-release-policy.md
+++ b/docs/decisions/0043-public-ci-and-release-policy.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** 2026-08-25
-- **Related:** [WH-438](https://app.plane.so/techprogress/browse/WH-438/)
+- **Related:** [Plane WH-438](https://ontrack.sh/projects/WH/issues/WH-278)
 
 ## Context
 

--- a/docs/decisions/0044-prepare-history-before-publication.md
+++ b/docs/decisions/0044-prepare-history-before-publication.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** 2026-08-25
-- **Related:** [WH-437](https://app.plane.so/techprogress/browse/WH-437/)
+- **Related:** [Plane WH-437](https://ontrack.sh/projects/WH/issues/WH-272)
 
 ## Context
 

--- a/docs/decisions/0045-stage-the-first-public-beta-release.md
+++ b/docs/decisions/0045-stage-the-first-public-beta-release.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** 2026-08-25
-- **Related:** [WH-440](https://app.plane.so/techprogress/browse/WH-440/)
+- **Related:** [Plane WH-440](https://ontrack.sh/projects/WH/issues/WH-23)
 
 ## Context
 

--- a/docs/decisions/0046-make-readmes-entry-points.md
+++ b/docs/decisions/0046-make-readmes-entry-points.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** 2026-08-26
-- **Related:** [WH-441](https://app.plane.so/techprogress/browse/WH-441/)
+- **Related:** [Plane WH-441](https://ontrack.sh/projects/WH/issues/WH-502)
 
 ## Context
 

--- a/docs/decisions/0048-extract-typescript-opentelemetry-adapter.md
+++ b/docs/decisions/0048-extract-typescript-opentelemetry-adapter.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** 2026-08-27
-- **Related:** [WH-446](https://app.plane.so/techprogress/browse/WH-446/), [ADR 0024](0024-metrics-instrument-lifecycle.md), [ADR 0041](0041-apache-2-and-contributor-agreement.md)
+- **Related:** [Plane WH-446](https://ontrack.sh/projects/WH/issues/WH-233), [ADR 0024](0024-metrics-instrument-lifecycle.md), [ADR 0041](0041-apache-2-and-contributor-agreement.md)
 
 ## Context
 

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -8,7 +8,7 @@ document never restates them.
 Statuses:
 
 - **Supported.** Shipped in that language and covered by tests in this repository.
-- **Planned.** Deliberately sequenced work with an open Plane work item. The work item owns the
+- **Planned.** Deliberately sequenced work with an open Ontrack Issue. The Issue owns the
   acceptance criteria; this matrix records the resulting language support.
 - **Absent.** Not shipped and not scheduled. An Absent cell is a fact, not a commitment.
 
@@ -79,7 +79,7 @@ telemetry, and graceful shutdown.
 
 <!-- END GENERATED PARITY WORKER -->
 
-Plane owns the SDK roadmap, sequencing, blockers, and completion state. This document changes only
+Ontrack owns the SDK roadmap, sequencing, blockers, and completion state. This document changes only
 when repository tests prove a capability has shipped or been withdrawn.
 
 ## Product operator capability
@@ -140,12 +140,12 @@ and every runtime fixture through `python/tests/test_worker_runtime_conformance.
 `typescript/core/test/support/parity-capabilities.ts`. `pnpm parity:check` fails if the checked-in
 document is stale. Every Supported cell must name an existing test file for that surface. The file
 must match every evidence pattern. Every Absent cell must record why it is absent. Every Planned
-cell must name a Plane work item, whose link the generator also writes.
+cell must name an Ontrack Issue, whose link the generator also writes.
 
 That check binds the document to declared evidence, not to a proof of behaviour — no static check
 can supply one. Naming a test file that never exercises the capability would satisfy it. The rule
 this document states still governs: a cell says Supported because tests prove it, and generation
 stops the published view from becoming another source of truth.
 
-<!-- BEGIN GENERATED PARITY PLANE LINKS -->
-<!-- END GENERATED PARITY PLANE LINKS -->
+<!-- BEGIN GENERATED PARITY ONTRACK LINKS -->
+<!-- END GENERATED PARITY ONTRACK LINKS -->

--- a/docs/tracker-history.md
+++ b/docs/tracker-history.md
@@ -1,0 +1,16 @@
+# Tracker history
+
+Workhorse used Plane before production Ontrack became its authoritative task system. The commit
+that first adds this file is the public repository's tracker boundary; its commit timestamp is the
+cutover timestamp. Find it with `git log --diff-filter=A --format='%H %cI' -- docs/tracker-history.md`.
+
+A `WH-*` identifier in a commit subject before that boundary names a Plane work item. The same form
+after the boundary names a native Issue in the Ontrack `Workhorse` Project. Git history remains
+unchanged, so the repository never guesses which tracker an identifier belongs to without checking
+the boundary commit.
+
+Imported Plane work items have new Ontrack keys. Their descriptions contain a `Plane provenance`
+section with the original source key and UUID, plus a machine-readable `plane-work-item-id` marker.
+Search production Ontrack for that source key or UUID when following an old commit. The private
+cutover bundle in `workhorse-operations` retains the exact source-to-destination mapping and
+canonical snapshot evidence.

--- a/docs/tracker-history.md
+++ b/docs/tracker-history.md
@@ -1,8 +1,10 @@
 # Tracker history
 
-Workhorse used Plane before production Ontrack became its authoritative task system. The commit
-that first adds this file is the public repository's tracker boundary; its commit timestamp is the
-cutover timestamp. Find it with `git log --diff-filter=A --format='%H %cI' -- docs/tracker-history.md`.
+Workhorse used Plane before production Ontrack became its authoritative task system. Plane Project
+`workhorse` was frozen at `2026-08-31T12:16:00.914028Z`; Ontrack became authoritative only after
+the WH-12 reconciliation and both repository switches reached `main`. The commit that first adds
+this file is the public repository's tracker boundary. Find it with
+`git log --diff-filter=A --format='%H %cI' -- docs/tracker-history.md`.
 
 A `WH-*` identifier in a commit subject before that boundary names a Plane work item. The same form
 after the boundary names a native Issue in the Ontrack `Workhorse` Project. Git history remains

--- a/scripts/generate-parity-tables.ts
+++ b/scripts/generate-parity-tables.ts
@@ -91,15 +91,17 @@ const plannedItems = [
     ].flatMap((cell) => ("planned" in cell ? [cell.planned] : [])),
   ),
 ].toSorted();
-const plannedStart = "<!-- BEGIN GENERATED PARITY PLANE LINKS -->";
-const plannedEnd = "<!-- END GENERATED PARITY PLANE LINKS -->";
+const plannedStart = "<!-- BEGIN GENERATED PARITY ONTRACK LINKS -->";
+const plannedEnd = "<!-- END GENERATED PARITY ONTRACK LINKS -->";
 const plannedPattern = new RegExp(`${plannedStart}[\\s\\S]*?${plannedEnd}`);
-if (!plannedPattern.test(generated)) throw new Error("Missing generated parity Plane link markers");
+if (!plannedPattern.test(generated)) {
+  throw new Error("Missing generated parity Ontrack link markers");
+}
 const withLinks = generated.replace(
   plannedPattern,
   [
     plannedStart,
-    ...plannedItems.map((item) => `[${item}]: https://app.plane.so/techprogress/browse/${item}/`),
+    ...plannedItems.map((item) => `[${item}]: https://ontrack.sh/projects/WH/issues/${item}`),
     plannedEnd,
   ].join("\n"),
 );

--- a/typescript/core/test/parity-matrix.test.ts
+++ b/typescript/core/test/parity-matrix.test.ts
@@ -174,8 +174,8 @@ describe("parity matrix", () => {
     expect(unexplainedAbsent(productCells.map(({ row, target }) => row[target]))).toEqual([]);
   });
 
-  it("links the Plane work item behind every Planned cell", () => {
-    // A Planned cell's evidence is the open work item that owns the gap. The document must link
+  it("links the Ontrack Issue behind every Planned cell", () => {
+    // A Planned cell's evidence is the open Issue that owns the gap. The document must link
     // it, so the cell cannot outlive the work it points at unnoticed.
     const unlinked = [
       ...registryCells.map(({ row, language }) => row[language]),
@@ -183,7 +183,11 @@ describe("parity matrix", () => {
     ]
       .filter((cell) => "planned" in cell)
       .map((cell) => ("planned" in cell ? cell.planned : ""))
-      .filter((item) => !/^WH-\d+$/.test(item) || !markdown.includes(`[${item}]: https://`));
+      .filter(
+        (item) =>
+          !/^WH-\d+$/.test(item) ||
+          !markdown.includes(`[${item}]: https://ontrack.sh/projects/WH/issues/${item}`),
+      );
     expect(unlinked).toEqual([]);
   });
 });

--- a/typescript/core/test/support/parity-capabilities.ts
+++ b/typescript/core/test/support/parity-capabilities.ts
@@ -13,7 +13,7 @@
  * An Absent cell carries a reason instead. Recording why keeps a deliberate boundary distinguishable
  * from a gap that is merely open.
  *
- * A Planned cell carries the Plane work item that owns the gap. The generator writes its link into
+ * A Planned cell carries the Ontrack Issue that owns the gap. The generator writes its link into
  * the document, so a Planned cell cannot outlive the work it points at unnoticed.
  */
 


### PR DESCRIPTION
Prepares the public tracker-authority switch after production importer qualification. This PR must remain unmerged until WH-12 completes the archived import and validates the projected historical mappings.