### PR TITLE
[WH-503] Reduce CI contention and remove timing races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
-# Public CI policy lives in docs/decisions/0043-public-ci-and-release-policy.md. Pull requests run
-# boundary pairs for fast feedback. Pushes to main, nightly runs, and manual runs exercise every
-# language/database combination declared in support.json.
+# Public CI policy lives in docs/decisions/0043-public-ci-and-release-policy.md. Pull requests and
+# pushes run the newest supported combination. Daily runs verify packed installs, and weekly runs
+# exercise every language/database combination declared in support.json.
 name: CI
 
 on:
@@ -9,7 +9,8 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    - cron: "43 3 * * *"
+    - cron: "43 3 * * *" # Daily packed-install verification.
+    - cron: "17 4 * * 0" # Weekly full compatibility matrix.
   workflow_dispatch:
 
 permissions:
@@ -41,10 +42,11 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - id: matrix
-        run: pnpm --silent exec tsx scripts/ci-matrix.ts "$GITHUB_EVENT_NAME" >> "$GITHUB_OUTPUT"
+        run: pnpm --silent exec tsx scripts/ci-matrix.ts "$GITHUB_EVENT_NAME" "${{ github.event.schedule }}" >> "$GITHUB_OUTPUT"
 
   static:
     name: format, generated files, lint, security, types
+    if: github.event_name != 'schedule' || github.event.schedule == '17 4 * * 0'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -72,6 +74,7 @@ jobs:
 
   unit:
     name: environment-independent tests
+    if: github.event_name != 'schedule' || github.event.schedule == '17 4 * * 0'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -92,6 +95,7 @@ jobs:
   typescript:
     name: TypeScript (node ${{ matrix.node }}, postgres ${{ matrix.postgres }})
     needs: plan
+    if: github.event_name != 'schedule' || github.event.schedule == '17 4 * * 0'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -141,6 +145,7 @@ jobs:
   python:
     name: Python ${{ matrix.python }} (postgres ${{ matrix.postgres }})
     needs: plan
+    if: github.event_name != 'schedule' || github.event.schedule == '17 4 * * 0'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -183,6 +188,7 @@ jobs:
   go:
     name: Go ${{ matrix.go }} (postgres ${{ matrix.postgres }})
     needs: plan
+    if: github.event_name != 'schedule' || github.event.schedule == '17 4 * * 0'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -223,6 +229,7 @@ jobs:
 
   runtime-smoke:
     name: runtime smoke (${{ matrix.runtime }})
+    if: github.event_name != 'schedule' || github.event.schedule == '17 4 * * 0'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -266,6 +273,7 @@ jobs:
   packed:
     name: packed install (node ${{ matrix.node }})
     needs: plan
+    if: github.event_name == 'workflow_dispatch' || github.event.schedule == '43 3 * * *'
     runs-on: ubuntu-latest
     timeout-minutes: 40
     strategy:
@@ -340,11 +348,11 @@ jobs:
   required:
     name: required
     if: always()
-    needs: [static, unit, typescript, python, go, runtime-smoke, packed]
+    needs: [plan, static, unit, typescript, python, go, runtime-smoke, packed]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
       RESULTS: ${{ toJSON(needs) }}
     steps:
       - name: Require every merge-gate job
-        run: echo "$RESULTS" | jq -e 'all(.[]; .result == "success")'
+        run: echo "$RESULTS" | jq -e 'all(.[]; .result == "success" or .result == "skipped")'

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -7,8 +7,8 @@ and `typescript/core/test/support-matrix.test.ts` fails when machine-readable co
 
 ## What "supported" means
 
-A version is supported when CI exercises every combination after each change reaches `main` and
-in the nightly run. Pull requests exercise boundary pairs before merge. In particular:
+A version is supported when the weekly CI run exercises every declared combination. Pull requests
+and pushes exercise the newest language and PostgreSQL versions for fast feedback. In particular:
 
 - **Supported.** In the CI matrix below. A regression on one of these is a release blocker.
 - **Expected to work, untested.** A PostgreSQL major newer than the tested set. Workhorse does not
@@ -30,10 +30,10 @@ This boundary is about correctness only. It is not a performance claim; see
 | Go         | 1.25 and newer | 1.25    | The module pins pgx v5.9.2.                             |
 | PostgreSQL | 15, 16, 17, 18 | 15      | No extension beyond the default `plpgsql` is installed. |
 
-Pull requests pair the oldest Node and PostgreSQL versions, then the newest versions. Pushes to
-`main`, nightly runs, and manual runs execute every Node and PostgreSQL combination. Packed-package
-tests run on the oldest Node version before merge and both Node versions after merge. Demo and site
-smoke tests run on every trigger.
+Pull requests and pushes run the newest Node.js and PostgreSQL versions. The weekly schedule runs
+every Node.js and PostgreSQL combination. The daily schedule runs the packed-package test on the
+newest Node.js version, and manual runs combine the latest-version lanes with that packed test.
+Demo and site smoke tests are temporarily disabled.
 
 Package managers: the repository is developed with pnpm, and the packed-install test installs the
 published tarballs with pnpm. npm and yarn are not exercised in CI; the packages are plain ESM with
@@ -44,16 +44,16 @@ major. Its `asyncpg` extra supports asyncpg 0.31 through the next major. Its pac
 source distribution and universal wheel, checks inline types, runs both real drivers, and executes
 every shared SQL scenario. `python/tests/test_release.py` installs the wheel and source distribution
 bare, with the compatibility `psycopg` extra, and with the `asyncpg` extra. It runs the lifecycle and async enqueue examples without repository imports, then
-checks that the active Python and PostgreSQL versions belong to this matrix. Pull requests run its
-oldest and newest boundary pairs. Pushes to `main`, nightly runs, and manual runs execute every
-Python and PostgreSQL combination.
+checks that the active Python and PostgreSQL versions belong to this matrix. Pull requests and
+pushes run the newest Python and PostgreSQL versions. The weekly schedule runs every Python and
+PostgreSQL combination.
 
 The Go module declares Go 1.25 or newer and supports its pinned pgx 5.9.2 release. Its repository
 lane exercises enqueue through pgx transactions, pgx pools, and `database/sql` with pgx stdlib. It
 also compiles and runs a separate module through a local `replace` directive. Another external
 module builds every Go example through the public import path. These tests prove the exported module
-surface without repository-only imports. Pull requests run Go against the newest PostgreSQL.
-Pushes to `main`, nightly runs, and manual runs execute Go against every PostgreSQL major.
+surface without repository-only imports. Pull requests and pushes run Go against the newest
+PostgreSQL. The weekly schedule runs Go against every supported PostgreSQL major.
 
 ## JS runtime smoke tier
 

--- a/docs/decisions/0043-public-ci-and-release-policy.md
+++ b/docs/decisions/0043-public-ci-and-release-policy.md
@@ -1,4 +1,4 @@
-# ADR 0043: Run boundary CI before merge and the full support matrix on main
+# ADR 0043: Run latest-version CI continuously and compatibility checks on schedules
 
 - **Status:** Accepted
 - **Date:** 2026-08-25
@@ -15,24 +15,24 @@ storage still use the repository quota, so free compute does not justify retaini
 
 ## Decision
 
-`.github/workflows/ci.yml` runs on pull requests to `main`, pushes to `main`, a nightly schedule,
-and manual dispatches. Pull requests test the oldest language against the oldest PostgreSQL and
-the newest language against the newest PostgreSQL. Go has one supported language line, so its pull
-request lane runs against the newest PostgreSQL. Pushes, schedules, and manual runs test every
-language and PostgreSQL combination in `support.json`.
+`.github/workflows/ci.yml` runs on pull requests to `main`, pushes to `main`, daily and weekly
+schedules, and manual dispatches. Pull requests and pushes test each language at its newest
+supported version against the newest PostgreSQL. The weekly schedule tests every language and
+PostgreSQL combination in `support.json`. The daily schedule runs only the packed-install test on
+the newest Node.js version. A manual dispatch runs the latest-version lanes and the packed test.
 
 Fork pull requests use `pull_request`, standard GitHub-hosted runners, and a read-only
 `GITHUB_TOKEN`. CI receives no secrets and never uses `pull_request_target`. GitHub must require
 maintainer approval before any outside collaborator's workflow runs.
 
 The branch ruleset for `main` requires a pull request and the single `CI / required` check. That
-aggregate job fails unless static checks, unit tests, every trigger-specific matrix lane, runtime
-smoke tests, and packed installs pass. Demo and site smoke tests are temporarily excluded because
-their full build dominates CI time. This stable name keeps matrix changes from invalidating branch
-protection.
+aggregate job fails when any job selected for that trigger fails. It accepts deliberately skipped
+jobs, so packed installs can stay out of pull requests and pushes while language lanes stay out of
+the daily packed run. Demo and site smoke tests are temporarily excluded because their full build
+dominates CI time. This stable name keeps matrix changes from invalidating branch protection.
 
-Each language matrix runs at most two lanes concurrently. The cap reduces contention between the
-database-heavy suites while preserving parallel feedback across languages and PostgreSQL versions.
+Each language matrix runs at most two lanes concurrently. The cap limits database contention during
+the weekly compatibility run without affecting the single-lane pull request and push feedback.
 
 `.github/workflows/benchmark.yml` runs smoke benchmarks after pushes to `main` and nightly. It is
 informational and is not a required check because timing on shared hardware is not comparable.
@@ -49,9 +49,9 @@ before it creates and pushes the annotated tag.
 
 ## Consequences
 
-Pull requests get bounded feedback rather than exhaustive support proof. A merge to `main` runs
-the full matrix, and the nightly run detects dependency or runner-image drift without a source
-change.
+Pull requests and pushes get fast latest-version feedback rather than exhaustive support proof. The
+weekly run checks older supported combinations, and the daily packed run detects assembly or clean
+consumer installation regressions without adding ten minutes to every change.
 
 GitHub Actions remain disabled until the repository is public. When it becomes public, maintainers
 must enable Actions, create the two protected environments, add the branch and tag rulesets, and

--- a/python/tests/test_worker.py
+++ b/python/tests/test_worker.py
@@ -154,7 +154,7 @@ def test_durable_sleeps_release_ownership_and_survive_a_swallowed_sentinel(
             nonlocal handler_calls
             handler_calls += 1
             with suppress(BaseException):
-                context.sleep("relative", 40)
+                context.sleep("relative", 30_000)
             if handler_calls >= 2:
                 try:
                     context.sleep_until(
@@ -180,7 +180,17 @@ def test_durable_sleeps_release_ownership_and_survive_a_swallowed_sentinel(
             "SELECT count(*) FROM workhorse.attempt_history WHERE job_id = %s", (job_id,)
         ).fetchone() == (0,)
 
-        sleep(0.06)
+        worker_connection.execute(
+            "UPDATE workhorse.job_wait SET wake_at = clock_timestamp() - interval '1 millisecond' "
+            "WHERE job_id = %s AND wait_name = 'relative'",
+            (job_id,),
+        )
+        worker_connection.execute(
+            "UPDATE workhorse.job_runtime "
+            "SET run_at = clock_timestamp() - interval '1 millisecond' "
+            "WHERE job_id = %s",
+            (job_id,),
+        )
         assert worker.run_once() is True
         outcome = worker_connection.execute(
             "SELECT state, current_attempt, result FROM workhorse.job_outcome WHERE job_id = %s",

--- a/scripts/ci-matrix.ts
+++ b/scripts/ci-matrix.ts
@@ -12,19 +12,13 @@ interface Matrix<T> {
   readonly include: readonly T[];
 }
 
+export const WEEKLY_COMPATIBILITY_SCHEDULE = "17 4 * * 0";
+
 export interface CiMatrices {
   readonly typescript: Matrix<{ readonly node: number; readonly postgres: number }>;
   readonly python: Matrix<{ readonly python: string; readonly postgres: number }>;
   readonly go: Matrix<{ readonly go: string; readonly postgres: number }>;
   readonly packed: Matrix<{ readonly node: number }>;
-}
-
-function bounds<T>(values: readonly T[]): readonly [T, T] {
-  const first = values[0];
-  const last = values.at(-1);
-  if (first === undefined || last === undefined)
-    throw new Error("CI support lists cannot be empty");
-  return [first, last];
 }
 
 function crossProduct<AKey extends string, A, BKey extends string, B>(
@@ -40,31 +34,26 @@ function crossProduct<AKey extends string, A, BKey extends string, B>(
   );
 }
 
-export function buildCiMatrices(support: Support, eventName: string): CiMatrices {
+export function buildCiMatrices(support: Support, eventName: string, schedule = ""): CiMatrices {
   const goVersion = support.go.minimum.replace(/\.0$/, "");
+  const newestNode = support.node.tested.at(-1);
+  const newestPostgres = support.postgres.tested.at(-1);
+  const newestPython = support.python.tested.at(-1);
+  if (newestNode === undefined || newestPostgres === undefined || newestPython === undefined)
+    throw new Error("CI support lists cannot be empty");
 
-  if (eventName === "pull_request") {
-    const [oldestNode, newestNode] = bounds(support.node.tested);
-    const [oldestPostgres, newestPostgres] = bounds(support.postgres.tested);
-    const [oldestPython, newestPython] = bounds(support.python.tested);
-
+  if (eventName !== "schedule" || schedule !== WEEKLY_COMPATIBILITY_SCHEDULE) {
     return {
       typescript: {
-        include: [
-          { node: oldestNode, postgres: oldestPostgres },
-          { node: newestNode, postgres: newestPostgres },
-        ],
+        include: [{ node: newestNode, postgres: newestPostgres }],
       },
       python: {
-        include: [
-          { python: oldestPython, postgres: oldestPostgres },
-          { python: newestPython, postgres: newestPostgres },
-        ],
+        include: [{ python: newestPython, postgres: newestPostgres }],
       },
       go: {
         include: [{ go: goVersion, postgres: newestPostgres }],
       },
-      packed: { include: [{ node: oldestNode }] },
+      packed: { include: [{ node: newestNode }] },
     };
   }
 
@@ -81,7 +70,7 @@ export function buildCiMatrices(support: Support, eventName: string): CiMatrices
         postgres,
       })),
     },
-    packed: { include: support.node.tested.map((node) => ({ node })) },
+    packed: { include: [{ node: newestNode }] },
   };
 }
 
@@ -94,7 +83,7 @@ async function main(): Promise<void> {
   ) as {
     readonly support: Support;
   };
-  const matrices = buildCiMatrices(manifest.support, eventName);
+  const matrices = buildCiMatrices(manifest.support, eventName, process.argv[3]);
   for (const [name, matrix] of Object.entries(matrices)) {
     process.stdout.write(`${name}=${JSON.stringify(matrix)}\n`);
   }

--- a/site/content/docs/compatibility.mdx
+++ b/site/content/docs/compatibility.mdx
@@ -78,7 +78,7 @@ compatibility.
 
 ## Bun and Deno
 
-Bun and Deno hold a smoke-tested tier, not support. On pull requests, pushes to `main`, and nightly
+Bun and Deno hold a smoke-tested tier, not support. On pull requests, pushes to `main`, and weekly
 runs, CI executes an enqueue, claim, and complete round-trip through the built package against
 PostgreSQL under the latest release of each; `SMOKE_TESTED_JS_RUNTIMES` exports the tier to tooling. A green lane proves the driver
 connects, the schema installs, and one job completes there — the full test suites run under
@@ -111,10 +111,10 @@ The Go module records independent versions in `go/CHANGELOG.md`. The repository 
 runs the full gate before it creates and pushes the matching `go/vX.Y.Z` tag.
 
 GitHub Actions remain disabled while the repository is private, so these release paths are defined
-but must not run until that restriction is lifted. Once public, pull requests run support-boundary
-pairs and `main` plus nightly runs execute the full matrix. Branch protection requires the stable
-`CI / required` check, and protected npm and PyPI environments require a second person to approve
-publication.
+but must not run until that restriction is lifted. Once public, pull requests and pushes run the
+newest supported versions, the weekly schedule runs the full compatibility matrix, and the daily
+schedule verifies packed installs. Branch protection requires the stable `CI / required` check,
+and protected npm and PyPI environments require a second person to approve publication.
 
 One honest caveat: support proves correctness under the tested matrix. It does not promise a
 throughput level for your database, payloads, handlers, or deployment topology.

--- a/typescript/core/test/integration-signals.test.ts
+++ b/typescript/core/test/integration-signals.test.ts
@@ -457,13 +457,30 @@ describe("signals", () => {
   });
 
   it("uses the PostgreSQL job deadline as the signal timeout", async () => {
-    const id = await queue.enqueue("signal-timeout", {}, { deadline: new Date(Date.now() + 100) });
+    const deadline = new Date(Date.now() + 30_000);
+    const id = await queue.enqueue("signal-timeout", {}, { deadline });
     const worker = new Worker(queue, { workerId: "signal-timeout-worker" }).handle(
       "signal-timeout",
       async (_payload, context) => context.waitForSignal("approval"),
     );
     expect(await worker.runOnce()).toBe(true);
-    await sleep(130);
+    const stored = await pool.query<{ deadline_at: Date; timeout_at: Date }>(
+      `SELECT runtime.deadline_at, signal.timeout_at
+         FROM workhorse.job_runtime runtime
+         JOIN workhorse.job_signal_wait signal ON signal.job_id = runtime.job_id
+        WHERE runtime.job_id = $1`,
+      [id],
+    );
+    expect(stored.rows).toEqual([{ deadline_at: deadline, timeout_at: deadline }]);
+
+    // Move the durable PostgreSQL deadline rather than waiting on a narrow wall-clock window. The
+    // equality above is the contract under test; this update only makes the timeout due now.
+    await pool.query(
+      `UPDATE workhorse.job_runtime
+          SET deadline_at = clock_timestamp() - interval '1 millisecond'
+        WHERE job_id = $1`,
+      [id],
+    );
     await queue.tick();
 
     await expect(admin.getJob(id)).resolves.toMatchObject({

--- a/typescript/core/test/support-matrix.test.ts
+++ b/typescript/core/test/support-matrix.test.ts
@@ -11,7 +11,7 @@ import {
   SUPPORTED_POSTGRES_MAJORS,
 } from "../src/support.js";
 import { publishedPackages } from "../../../scripts/packages.js";
-import { buildCiMatrices } from "../../../scripts/ci-matrix.js";
+import { buildCiMatrices, WEEKLY_COMPATIBILITY_SCHEDULE } from "../../../scripts/ci-matrix.js";
 
 // A supported-version contract is only worth stating if the statement and the thing that tests it
 // cannot drift apart. support.json is the source of truth; everything below is a consumer of it,
@@ -187,21 +187,19 @@ describe("declared engines", () => {
 });
 
 describe("continuous integration", () => {
-  it("uses boundary pairs on pull requests and the full support matrix elsewhere", async () => {
+  it("uses latest versions continuously and the full support matrix weekly", async () => {
     const manifest = await readSupportManifest();
     const pullRequest = buildCiMatrices(manifest.support, "pull_request");
-    const full = buildCiMatrices(manifest.support, "push");
+    const push = buildCiMatrices(manifest.support, "push");
+    const daily = buildCiMatrices(manifest.support, "schedule", "43 3 * * *");
+    const full = buildCiMatrices(manifest.support, "schedule", WEEKLY_COMPATIBILITY_SCHEDULE);
 
-    expect(pullRequest.typescript.include).toEqual([
-      { node: 22, postgres: 15 },
-      { node: 24, postgres: 18 },
-    ]);
-    expect(pullRequest.python.include).toEqual([
-      { python: "3.10", postgres: 15 },
-      { python: "3.14", postgres: 18 },
-    ]);
+    expect(pullRequest.typescript.include).toEqual([{ node: 24, postgres: 18 }]);
+    expect(pullRequest.python.include).toEqual([{ python: "3.14", postgres: 18 }]);
     expect(pullRequest.go.include).toEqual([{ go: "1.25", postgres: 18 }]);
-    expect(pullRequest.packed.include).toEqual([{ node: 22 }]);
+    expect(pullRequest.packed.include).toEqual([{ node: 24 }]);
+    expect(push).toEqual(pullRequest);
+    expect(daily).toEqual(pullRequest);
 
     expect(full.typescript.include).toHaveLength(
       manifest.support.node.tested.length * manifest.support.postgres.tested.length,
@@ -210,7 +208,7 @@ describe("continuous integration", () => {
       manifest.support.python.tested.length * manifest.support.postgres.tested.length,
     );
     expect(full.go.include).toHaveLength(manifest.support.postgres.tested.length);
-    expect(full.packed.include).toEqual([{ node: 22 }, { node: 24 }]);
+    expect(full.packed.include).toEqual([{ node: 24 }]);
     for (const node of manifest.support.node.tested) {
       for (const postgres of manifest.support.postgres.tested) {
         expect(full.typescript.include).toContainEqual({ node, postgres });
@@ -233,8 +231,19 @@ describe("continuous integration", () => {
     expect(workflow).toContain("schedule:");
     expect(workflow).toContain("name: required");
     expect(workflow).toContain(
-      "needs: [static, unit, typescript, python, go, runtime-smoke, packed]",
+      "needs: [plan, static, unit, typescript, python, go, runtime-smoke, packed]",
     );
+    expect(workflow).toContain('cron: "43 3 * * *" # Daily packed-install verification.');
+    expect(workflow).toContain('cron: "17 4 * * 0" # Weekly full compatibility matrix.');
+    expect(workflow).toContain(
+      "if: github.event_name == 'workflow_dispatch' || github.event.schedule == '43 3 * * *'",
+    );
+    expect(
+      workflow.match(
+        /if: github\.event_name != 'schedule' \|\| github\.event\.schedule == '17 4 \* \* 0'/g,
+      ),
+    ).toHaveLength(6);
+    expect(workflow).toContain('all(.[]; .result == "success" or .result == "skipped")');
     expect(workflow).toContain(
       "name: demo and site smoke\n    if: ${{ false }} # Temporarily disabled",
     );


### PR DESCRIPTION
## What changed

- replace TypeScript signal-deadline wall-clock synchronization with a durable database transition
- replace Python durable-wait wall-clock synchronization with a durable database transition
- run only the newest language/PostgreSQL combination on pull requests and pushes
- run the full compatibility cross-product on a weekly schedule
- run packed-install verification daily and on manual dispatch
- keep the stable required aggregate strict for selected lanes and tolerant of intentional skips

## Verification

- TypeScript signal regression: 10 consecutive passes
- Python durable-wait regression: 10 consecutive passes
- pnpm test:database:typescript: 609 passed, 2 skipped
- pnpm python:test: 150 passed
- support-matrix guard: 39 passed
- planner output verified for pull request, push, daily, and weekly modes
- pnpm typecheck
- formatting and lint checks