### PR TITLE
[WH-503] Remove Python readiness timing races

### DIFF
--- a/python/examples/lifecycle.py
+++ b/python/examples/lifecycle.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from time import monotonic, sleep
+from time import sleep
 from uuid import uuid4
 
 import psycopg
@@ -9,9 +9,8 @@ import psycopg
 from workhorse import ChildJobRequest, EnqueueOptions, HandlerContext, Json, Queue, Worker
 
 
-def run_once_when_ready(worker: Worker, timeout: float = 2.0) -> None:
-    deadline = monotonic() + timeout
-    while monotonic() < deadline:
+def run_once_when_ready(worker: Worker, attempts: int = 100) -> None:
+    for _attempt in range(attempts):
         if worker.run_once():
             return
         sleep(0.02)

--- a/python/tests/test_release.py
+++ b/python/tests/test_release.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import runpy
 import subprocess
 import sys
 from pathlib import Path
@@ -23,6 +24,21 @@ def _repository_json(*parts: str) -> dict[str, Any]:
 
 def _repository_toml(*parts: str) -> dict[str, Any]:
     return tomli.loads(_repository_file(*parts))
+
+
+def test_lifecycle_ready_polling_is_bounded_by_attempts() -> None:
+    class ReadyOnSecondPoll:
+        calls = 0
+
+        def run_once(self) -> bool:
+            self.calls += 1
+            return self.calls == 2
+
+    worker = ReadyOnSecondPoll()
+    lifecycle = runpy.run_path(str(Path(__file__).parents[1] / "examples" / "lifecycle.py"))
+    run_once_when_ready = lifecycle["run_once_when_ready"]
+    run_once_when_ready(worker, attempts=2)
+    assert worker.calls == 2
 
 
 def test_readme_example_matches_release_tested_example() -> None:

--- a/python/tests/test_worker.py
+++ b/python/tests/test_worker.py
@@ -9,6 +9,7 @@ from typing import Any
 import psycopg
 import pytest
 
+import workhorse.worker as worker_module
 from workhorse import (
     CancellationRequestedError,
     CheckpointConflictError,
@@ -1310,21 +1311,40 @@ def test_worker_delivers_and_acknowledges_cancellation(database_url: str) -> Non
         assert attempt_count == (1,)
 
 
-def test_worker_classifies_an_absolute_deadline(database_url: str) -> None:
+def test_worker_classifies_an_absolute_deadline(
+    database_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
     observed_reason: list[BaseException] = []
+    deadline_advanced = Event()
+
+    def expiration_after_handler_starts(
+        _expiration_at: datetime | None, _retry_at: float | None
+    ) -> float:
+        assert deadline_advanced.wait(timeout=5)
+        return 0.0
+
+    monkeypatch.setattr(worker_module, "_expiration_delay", expiration_after_handler_starts)
 
     with (
         psycopg.connect(database_url) as enqueue_connection,
         psycopg.connect(database_url, autocommit=True) as worker_connection,
+        psycopg.connect(database_url, autocommit=True) as deadline_connection,
     ):
         job_id = Queue(enqueue_connection).enqueue(
             "deadline.active",
             {},
-            EnqueueOptions(deadline=datetime.now(timezone.utc) + timedelta(milliseconds=180)),
+            EnqueueOptions(deadline=datetime.now(timezone.utc) + timedelta(hours=1)),
         )
         enqueue_connection.commit()
 
         def wait_for_deadline(_payload: object, context: HandlerContext) -> None:
+            deadline_connection.execute(
+                "UPDATE workhorse.job_runtime "
+                "SET deadline_at = clock_timestamp() - interval '1 millisecond' "
+                "WHERE job_id = %s",
+                (job_id,),
+            )
+            deadline_advanced.set()
             assert context.cancellation.wait(timeout=5)
             observed_reason.append(context.cancellation.reason)
             context.cancellation.raise_if_cancelled()
@@ -1336,9 +1356,7 @@ def test_worker_classifies_an_absolute_deadline(database_url: str) -> None:
             heartbeat_ms=400,
         ).handle("deadline.active", wait_for_deadline)
 
-        started_at = monotonic()
         assert worker.run_once() is True
-        assert monotonic() - started_at < 0.32
         assert len(observed_reason) == 1
         assert isinstance(observed_reason[0], DeadlineExceededError)
         outcome = worker_connection.execute(


### PR DESCRIPTION
Fixes the two Python timing failures from automatic main run 33407951406.

The lifecycle example now bounds readiness by claim attempts, so scheduler pauses do not consume its budget. The absolute-deadline regression waits for handler ownership, advances the durable runtime deadline, and exercises the real PostgreSQL expiration path.

Verification:
- focused regressions passed 10 consecutive runs
- packaged lifecycle example passed
- full Python suite passed: 151 tests
- Python format, lint, and typecheck passed
- pre-commit hooks passed