### PR TITLE
[WH-506] Disable JIT for dashboard events

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2117,8 +2117,9 @@ each string filter to 200 characters before the backend calls the function.
 `jobId` before merging `dashboard_job_event_v1` with `dashboard_attempt_history_v1`. Each source
 reads at most `page * pageSize` rows before the merge, while separate bounded counts produce
 `total`. The wire validator limits `page` to 100 and each string filter to 200 characters before
-the backend calls the function. The function returns the complete version 1 events JSON document,
-including retention days from `dashboard_retention_policy_v1`.
+the backend calls the function. The function disables JIT because compiling its generic partitioned
+plan costs more than executing the bounded reads. It returns the complete version 1 events JSON
+document, including retention days from `dashboard_retention_policy_v1`.
 
 `dashboard_event_detail_v1(p_input jsonb)` accepts the stable `event:<UUIDv7 event_id>` or
 `attempt:<UUIDv7 attempt_id>` identity. It returns the complete version 1 event-detail JSON document.

--- a/sql/schema/current.sql
+++ b/sql/schema/current.sql
@@ -11793,6 +11793,7 @@ $$;
 CREATE OR REPLACE FUNCTION workhorse.dashboard_events_v1(p_input jsonb)
 RETURNS jsonb
 LANGUAGE sql
+SET jit = off
 AS $$
   WITH parameters AS (
     SELECT clock_timestamp() AS captured_at,

--- a/typescript/core/test/integration-dashboard-procedure-plans.test.ts
+++ b/typescript/core/test/integration-dashboard-procedure-plans.test.ts
@@ -49,16 +49,22 @@ describe("dashboard procedure plans", () => {
 
   afterAll(async () => database.teardown());
 
-  it("disables JIT for the activity procedure's generic high-cost plan", async () => {
-    const result = await database.pool.query<{ proconfig: string[] | null }>(
-      `SELECT routine.proconfig
+  it("disables JIT for generic high-cost dashboard plans", async () => {
+    // PostgreSQL applies proconfig before planning the function body, so this covers every
+    // input-specific events branch without relying on a wall-clock assertion.
+    const result = await database.pool.query<{ proname: string; proconfig: string[] | null }>(
+      `SELECT routine.proname, routine.proconfig
          FROM pg_proc routine
          JOIN pg_namespace namespace ON namespace.oid = routine.pronamespace
         WHERE namespace.nspname = 'workhorse'
-          AND routine.proname = 'dashboard_activity_v1'`,
+          AND routine.proname IN ('dashboard_activity_v1', 'dashboard_events_v1')
+        ORDER BY routine.proname`,
     );
 
-    expect(result.rows).toEqual([{ proconfig: ["jit=off"] }]);
+    expect(result.rows).toEqual([
+      { proname: "dashboard_activity_v1", proconfig: ["jit=off"] },
+      { proname: "dashboard_events_v1", proconfig: ["jit=off"] },
+    ]);
   });
 
   it("enriches only the requested task page", async () => {


### PR DESCRIPTION
## Summary

- disable JIT only while PostgreSQL plans and executes dashboard_events_v1
- extend the dashboard plan regression test to cover the Events procedure
- document why this bounded generic partitioned plan opts out of JIT

## Diagnosis

The public Events RPC consistently took about 2.6 seconds regardless of window, source kind, page size, event type, or job ID. On the Oldi production database, the default function call took 2492.138 ms with JIT enabled and 18.341 ms with JIT disabled. Both runs touched 5,373 shared buffers, while planning stayed near 2 ms, which isolates the delay to per-call JIT compilation.

The setting is function-local, so database-wide JIT remains available for queries that benefit from it.

## Verification

- focused dashboard procedure plan tests: 2 passed
- Workhorse dashboard Events integration suite: 12 passed
- schema tests: 20 passed
- root TypeScript, Python, and Go type checks
- SQL catalogue check, targeted lint and formatting checks
- development runtime build
- pre-commit hook
- GitHub CI required check passed after rerunning one unrelated Go timing failure

## Operational verification

Applied ALTER FUNCTION workhorse.dashboard_events_v1(jsonb) SET jit = off to both Oldi demo databases after validating their database and role identities. Production returned the Events RPC in 105-121 ms across three runs; staging returned it in 77-160 ms. No database was reset and no data was deleted. Merging this PR preserves the setting in future clean schema installations.