### PR TITLE
[WH-508] Repair and reschedule smoke benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,4 +1,4 @@
-# Smoke benchmarks on main.
+# Weekly smoke benchmarks on main.
 #
 # This workflow exists to detect *drift*, not to publish performance numbers. It runs the `smoke`
 # profile, which is small enough to finish in minutes on a shared runner and therefore far too
@@ -13,11 +13,10 @@
 name: Benchmark
 
 on:
-  push:
-    branches: [main]
   schedule:
-    # Nightly, off the hour, so a queued run does not compete with the cron spike.
-    - cron: "17 4 * * *"
+    # Weekly, after the compatibility matrix window, so the two informationally distinct runs do
+    # not start together.
+    - cron: "17 6 * * 0"
   workflow_dispatch:
 
 concurrency:
@@ -57,8 +56,8 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      # The suite runs from source through tsx, so no build is needed. The reset installs
-      # sql/schema.sql, which is what makes every run start from the same schema state.
+      # The benchmark script selects each workspace package's source export, so the adapter and
+      # core share one telemetry singleton without requiring built package artifacts.
       - run: pnpm db:reset:bench
 
       # The canonical report goes to a file; stdout would repeat the whole document into the log.

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -334,7 +334,7 @@ Raw claim samples and raw PostgreSQL plans are intentionally retained so derived
 
 ## Continuous smoke benchmarks
 
-`.github/workflows/benchmark.yml` runs the smoke profile on every push to `main`, nightly at 04:17 UTC, and on manual dispatch. It provisions PostgreSQL 18, runs `pnpm db:reset:bench`, then:
+`.github/workflows/benchmark.yml` runs the smoke profile weekly on Sunday at 06:17 UTC and on manual dispatch. It provisions PostgreSQL 18. The package script selects workspace source exports, so the workflow can run `pnpm db:reset:bench`, then:
 
 ```bash
 pnpm benchmark -- --suite all --profile smoke --output benchmark-report.json
@@ -351,8 +351,8 @@ Before uploading, the workflow asserts the report is `schemaVersion: 3`, carries
 The workflow answers one question: does the harness still run green, and has anything changed by an amount too large to be noise? It does not answer how fast Workhorse is.
 
 - **Assertions are the signal.** A lifecycle assertion that flips from passing to failing is a real regression at any profile. Investigate it directly.
-- **Timings are not a signal on their own.** The smoke profile runs 12 jobs over 2 repetitions on a shared runner. Confidence intervals at that size routinely span more than the mean, and consecutive nightly runs can differ by a factor of two with no code change between them.
-- **Only act on a sustained shift.** Treat a timing change as worth investigating when several consecutive runs move the same way and the new interval does not overlap the old one. A single slow night is runner noise.
+- **Timings are not a signal on their own.** The smoke profile runs 12 jobs over 2 repetitions on a shared runner. Confidence intervals at that size routinely span more than the mean, and consecutive runs can differ by a factor of two with no code change between them.
+- **Only act on a sustained shift.** Treat a timing change as worth investigating when several consecutive runs move the same way and the new interval does not overlap the old one. A single slow run is runner noise.
 - **Never compare across environments.** Runner hardware, PostgreSQL image, and settings all vary. Compare a workflow artifact only with other workflow artifacts, and read `environment` and `provenance` before concluding anything.
 - **Reproduce before recording.** A trend the workflow surfaces is a prompt to run `default` or `full` on stable hardware and record that artifact under `docs/benchmarks/`. The workflow artifact itself is never publication evidence.
 

--- a/docs/decisions/0043-public-ci-and-release-policy.md
+++ b/docs/decisions/0043-public-ci-and-release-policy.md
@@ -34,8 +34,9 @@ dominates CI time. This stable name keeps matrix changes from invalidating branc
 Each language matrix runs at most two lanes concurrently. The cap limits database contention during
 the weekly compatibility run without affecting the single-lane pull request and push feedback.
 
-`.github/workflows/benchmark.yml` runs smoke benchmarks after pushes to `main` and nightly. It is
-informational and is not a required check because timing on shared hardware is not comparable.
+`.github/workflows/benchmark.yml` runs smoke benchmarks weekly and on manual dispatch. It is
+informational and is not a required check because timing on shared hardware is not comparable. The
+benchmark selects workspace source exports so the adapter and core share one telemetry provider.
 
 npm and Python publication run only from matching version tags. Separate `npm` and `pypi`
 environments require a reviewer other than the person who pushed the tag, disallow self-review and

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "example:agentic-flow": "pnpm build:runtime && tsx scripts/with-env.ts node typescript/examples/agentic-flow.mjs",
     "health": "tsx scripts/with-env.ts sh -c 'WORKHORSE_DATABASE_URL=\"$DATABASE_URL_PRIMARY\" exec tsx typescript/core/src/cli/workhorse.ts health --json'",
     "health:bench": "tsx scripts/with-env.ts sh -c 'WORKHORSE_DATABASE_URL=\"$DATABASE_URL_BENCH\" exec tsx typescript/core/src/cli/workhorse.ts health --json'",
-    "benchmark": "tsx scripts/with-env.ts tsx typescript/core/src/cli/benchmark.ts",
+    "benchmark": "tsx scripts/with-env.ts tsx --conditions=workhorse-source typescript/core/src/cli/benchmark.ts",
     "benchmark:metrics-lifecycle": "tsx scripts/benchmark-metrics-lifecycle.ts",
     "benchmark:retention-strategies": "tsx scripts/with-env.ts tsx scripts/benchmark-retention-strategies.ts",
     "benchmark:dashboard-read-surface": "tsx scripts/with-env.ts tsx scripts/benchmark-dashboard-read-surface.ts",

--- a/typescript/core/benchmarks/scenarios.ts
+++ b/typescript/core/benchmarks/scenarios.ts
@@ -569,7 +569,7 @@ export const operationalScenarioContracts: readonly OperationalScenarioContract[
       "mixed outcomes settle independently without changing successful peers",
       "every admitted member consumes one slot and one policy admission per job",
       "lease recovery and stale fences isolate one lost member from its batch peers",
-      "serial and batched cohorts record claim cost through the same claim_v1 path over live ready-index work",
+      "serial and batched cohorts record claim cost through the same claim path over live ready-index work",
     ],
     metrics: [
       "jobsPerCohort",
@@ -4481,7 +4481,7 @@ async function batchDispatch(
       batchLingerMs,
       claimCalls: after.claimCalls - before.claimCalls,
       claimDurationsMs: after.claimDurationsMs.slice(before.claimDurationsMs.length),
-      successfulClaims: after.successfulClaimTimes.length - before.successfulClaimTimes.length,
+      claimedJobs: after.claimedJobs - before.claimedJobs,
       maxConcurrentClaims: after.maxConcurrentClaims,
       claimsWithoutFreeSlot: after.claimsWithoutFreeSlot - before.claimsWithoutFreeSlot,
     };
@@ -4537,14 +4537,15 @@ async function batchDispatch(
     );
     recordInvariant(
       assertions,
-      `${name} cohort successful claim count matches jobs`,
-      cohort.successfulClaims,
+      `${name} cohort claimed job count matches jobs`,
+      cohort.claimedJobs,
       jobsPerCohort,
     );
     recordInvariant(
       assertions,
       `${name} cohort claim cost samples are finite`,
-      cohort.claimDurationsMs.length >= jobsPerCohort &&
+      cohort.claimDurationsMs.length === cohort.claimCalls &&
+        cohort.claimCalls > 0 &&
         cohort.claimDurationsMs.every(Number.isFinite),
       true,
     );

--- a/typescript/core/test/integration-cron-schedules.test.ts
+++ b/typescript/core/test/integration-cron-schedules.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
-import { Queue, Worker } from "../src/index.js";
+import { Queue, Worker, type Queryable } from "../src/index.js";
 import { createIntegrationTestContext } from "./support/integration.js";
 import { WORKHORSE_SCHEMA_VERSION } from "../src/index.js";
 
@@ -20,6 +20,46 @@ interface CronOccurrenceFixture {
 const cronFixtures = JSON.parse(
   await readFile(new URL("../../../protocol/v1/cron-occurrences.json", import.meta.url), "utf8"),
 ) as CronOccurrenceFixture[];
+
+class ScheduleEvaluationQueue extends Queue {
+  constructor(
+    database: Queryable,
+    private readonly evaluationAt: Date,
+    private readonly coordination: {
+      before?: () => Promise<void>;
+      after?: () => void;
+    } = {},
+  ) {
+    super(database);
+  }
+
+  override async fireDueSchedules(
+    namespaces: readonly string[],
+    _now: Date,
+    catchupLimit: number,
+  ): Promise<void> {
+    await this.coordination.before?.();
+    try {
+      await super.fireDueSchedules(namespaces, this.evaluationAt, catchupLimit);
+    } finally {
+      this.coordination.after?.();
+    }
+  }
+}
+
+function orderedScheduleEvaluationQueues(
+  firstEvaluationAt: Date,
+  secondEvaluationAt: Date,
+): readonly [Queue, Queue] {
+  let releaseSecondEvaluation!: () => void;
+  const firstEvaluation = new Promise<void>((resolve) => {
+    releaseSecondEvaluation = resolve;
+  });
+  return [
+    new ScheduleEvaluationQueue(pool, firstEvaluationAt, { after: releaseSecondEvaluation }),
+    new ScheduleEvaluationQueue(pool, secondEvaluationAt, { before: () => firstEvaluation }),
+  ];
+}
 
 describe("cron schedules", () => {
   it.each(cronFixtures)("evaluates $id through PostgreSQL", async (fixture) => {
@@ -248,11 +288,13 @@ describe("cron schedules", () => {
         job: { type: "cron-tick", payload: { source: "worker" } },
       },
     ]);
-    const first = new Worker(queue, {
+    const occurrenceAt = new Date(Math.floor(Date.now() / 1_000) * 1_000);
+    const [firstQueue, secondQueue] = orderedScheduleEvaluationQueues(occurrenceAt, occurrenceAt);
+    const first = new Worker(firstQueue, {
       workerId: "scheduler-a",
       scheduleNamespaces: ["integration"],
     }).handle("cron-tick", () => ({ worker: "a" }));
-    const second = new Worker(queue, {
+    const second = new Worker(secondQueue, {
       workerId: "scheduler-b",
       scheduleNamespaces: ["integration"],
     }).handle("cron-tick", () => ({ worker: "b" }));
@@ -270,6 +312,45 @@ describe("cron schedules", () => {
     expect(
       (await pool.query("SELECT count(*)::integer AS count FROM workhorse.job")).rows[0]?.count,
     ).toBe(1);
+  });
+
+  it("treats adjacent recurring occurrences as distinct coordinated work", async () => {
+    await queue.syncSchedules("adjacent", [
+      {
+        name: "heartbeat",
+        schedule: "* * * * * *",
+        job: { type: "cron-adjacent", payload: null },
+      },
+    ]);
+    const firstOccurrenceAt = new Date(Math.floor(Date.now() / 1_000) * 1_000);
+    const secondOccurrenceAt = new Date(firstOccurrenceAt.getTime() + 1_000);
+    const [firstQueue, secondQueue] = orderedScheduleEvaluationQueues(
+      firstOccurrenceAt,
+      secondOccurrenceAt,
+    );
+    const first = new Worker(firstQueue, {
+      workerId: "scheduler-a",
+      scheduleNamespaces: ["adjacent"],
+    }).handle("cron-adjacent", () => ({ worker: "a" }));
+    const second = new Worker(secondQueue, {
+      workerId: "scheduler-b",
+      scheduleNamespaces: ["adjacent"],
+    }).handle("cron-adjacent", () => ({ worker: "b" }));
+
+    expect(await Promise.all([first.runOnce(), second.runOnce()])).toEqual([true, true]);
+    const occurrences = await pool.query<{ occurrence_at: Date }>(
+      `SELECT occurrence_at
+         FROM workhorse.schedule_occurrence
+        WHERE namespace = 'adjacent' AND schedule_name = 'heartbeat'
+        ORDER BY occurrence_at`,
+    );
+    expect(occurrences.rows.map((row) => row.occurrence_at.toISOString())).toEqual([
+      firstOccurrenceAt.toISOString(),
+      secondOccurrenceAt.toISOString(),
+    ]);
+    expect(
+      (await pool.query("SELECT count(*)::integer AS count FROM workhorse.job")).rows[0]?.count,
+    ).toBe(2);
   });
 
   it("lets different schedule namespaces progress on the same cadence", async () => {

--- a/typescript/core/test/support-matrix.test.ts
+++ b/typescript/core/test/support-matrix.test.ts
@@ -335,16 +335,21 @@ describe("continuous integration", () => {
     }
   });
 
-  it("benchmarks main on a supported PostgreSQL major under an explicit timeout", async () => {
+  it("benchmarks weekly on a supported PostgreSQL major under an explicit timeout", async () => {
     const workflow = await read(".github/workflows/benchmark.yml");
+    const manifest = await readManifest("package.json");
+    const scripts = manifest.scripts as Record<string, string>;
 
     // Without a ceiling a hung scenario occupies a runner for GitHub's six-hour default, so the
     // timeout is part of the contract rather than a tuning detail.
     expect(workflow).toMatch(/^\s*timeout-minutes: \d+$/m);
-    expect(workflow).toContain("branches: [main]");
+    expect(workflow).not.toMatch(/^  push:/m);
+    expect(workflow).toContain('cron: "17 6 * * 0"');
+    expect(workflow).toContain("workflow_dispatch:");
     expect(workflow).toContain("--profile smoke");
     expect(workflow).toContain("--output");
     expect(workflow).toContain("actions/upload-artifact");
+    expect(scripts.benchmark).toContain("--conditions=workhorse-source");
 
     const image = /image: postgres:(\d+)-alpine/.exec(workflow);
     expect(SUPPORTED_POSTGRES_MAJORS).toContain(Number(image?.[1]));


### PR DESCRIPTION
## Summary

- run the informational smoke benchmark weekly and by manual dispatch instead of on every push and nightly
- resolve workspace packages through `workhorse-source`, keeping the OpenTelemetry adapter and core in one module graph without requiring built artifacts
- count claimed jobs separately from successful batched claim statements in the batch-dispatch benchmark
- update the CI policy, benchmark runbook, and workflow contract test

## Diagnosis

The benchmark workflow failed before execution because the source-run scenario resolved `@stablemates/workhorse-otel` through its missing `dist` export. Building the package was insufficient because the compiled adapter registered telemetry against compiled core while the benchmark Worker came from source. Selecting the workspace source condition keeps one telemetry singleton.

Once setup passed, the complete smoke run exposed an existing assertion that treated successful `claim_many_v1` statements as claimed jobs even though one statement can return several rows.

## Verification

- complete fresh-reset `--suite all --profile smoke` run and workflow jq gate
- clean-artifact batch-dispatch run with core and OpenTelemetry `dist` directories absent
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit`
- pre-commit changed-scope checks
