### PR TITLE
[WH-430] Pin the release setup-uv action

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go/go.mod
-      - uses: astral-sh/setup-uv@v9
+      - uses: astral-sh/setup-uv@v9.0.0
       - run: pnpm install --frozen-lockfile
 
       - name: Check the tag against the Python version and changelog
@@ -75,7 +75,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: astral-sh/setup-uv@v9
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: false
       - uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go/go.mod
-      - uses: astral-sh/setup-uv@v9
+      - uses: astral-sh/setup-uv@v9.0.0
       - run: pnpm install --frozen-lockfile
 
       # A tag that disagrees with the manifests would publish a version nobody can reproduce from

--- a/typescript/core/test/support-matrix.test.ts
+++ b/typescript/core/test/support-matrix.test.ts
@@ -331,7 +331,7 @@ describe("continuous integration", () => {
       const workflow = await read(workflowPath);
       expect(workflow).toContain("actions/setup-go@v7");
       expect(workflow).toContain("go-version-file: go/go.mod");
-      expect(workflow).toContain("astral-sh/setup-uv@v9");
+      expect(workflow).toContain("astral-sh/setup-uv@v9.0.0");
     }
   });
 


### PR DESCRIPTION
Fix the release rehearsal blocker discovered by the first WH-430 dry runs.

- pin all release workflow setup-uv uses to the published v9.0.0 tag
- tighten the existing workflow contract test so a missing floating major cannot pass by substring

Verification:
- pnpm exec vitest run typescript/core/test/support-matrix.test.ts
- pre-commit core typecheck and changed-scope tests
- pnpm exec oxfmt --check on changed files

The failed dry runs stopped before checkout, and their publish jobs were skipped.