### PR TITLE
[WH-430] Match the release PostgreSQL client

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -50,6 +50,13 @@ jobs:
         with:
           go-version-file: go/go.mod
       - uses: astral-sh/setup-uv@v9.0.0
+      - name: Install matching PostgreSQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes postgresql-common
+          sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+          sudo apt-get install --yes postgresql-client-18
+          echo "/usr/lib/postgresql/18/bin" >> "$GITHUB_PATH"
       - run: pnpm install --frozen-lockfile
 
       - name: Check the tag against the Python version and changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,13 @@ jobs:
         with:
           go-version-file: go/go.mod
       - uses: astral-sh/setup-uv@v9.0.0
+      - name: Install matching PostgreSQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes postgresql-common
+          sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+          sudo apt-get install --yes postgresql-client-18
+          echo "/usr/lib/postgresql/18/bin" >> "$GITHUB_PATH"
       - run: pnpm install --frozen-lockfile
 
       # A tag that disagrees with the manifests would publish a version nobody can reproduce from

--- a/typescript/core/test/support-matrix.test.ts
+++ b/typescript/core/test/support-matrix.test.ts
@@ -335,6 +335,18 @@ describe("continuous integration", () => {
     }
   });
 
+  it("installs a PostgreSQL client that matches the release service", async () => {
+    for (const workflowPath of [
+      ".github/workflows/release.yml",
+      ".github/workflows/release-python.yml",
+    ]) {
+      const workflow = await read(workflowPath);
+      expect(workflow).toContain("image: postgres:18-alpine");
+      expect(workflow).toContain("sudo apt-get install --yes postgresql-client-18");
+      expect(workflow).toContain('echo "/usr/lib/postgresql/18/bin" >> "$GITHUB_PATH"');
+    }
+  });
+
   it("benchmarks weekly on a supported PostgreSQL major under an explicit timeout", async () => {
     const workflow = await read(".github/workflows/benchmark.yml");
     const manifest = await readManifest("package.json");


### PR DESCRIPTION
Fix the second WH-430 rehearsal blocker. Both release dry runs used pg_dump 16 against PostgreSQL 18 and failed the schema-migration equivalence check before artifacts were built.

- install the PostgreSQL 18 client in both release build jobs
- put its bin directory on GITHUB_PATH
- require matching service and client majors in the workflow contract test

Verification:
- pnpm exec vitest run typescript/core/test/support-matrix.test.ts
- pre-commit core typecheck and changed-scope tests
- pnpm exec oxfmt --check on changed files