### PR TITLE
[WH-430] Provision the packed release database

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -39,6 +39,7 @@ jobs:
     env:
       WORKHORSE_TEST_DATABASE_URL: postgres://workhorse:workhorse@localhost:5432/workhorse_test
       WORKHORSE_DEMO_DATABASE_URL: postgres://workhorse:workhorse@localhost:5432/workhorse_demo
+      DATABASE_URL_TEST_PACKED: postgres://workhorse:workhorse@localhost:5432/workhorse_test_packed
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
     env:
       WORKHORSE_TEST_DATABASE_URL: postgres://workhorse:workhorse@localhost:5432/workhorse_test
       WORKHORSE_DEMO_DATABASE_URL: postgres://workhorse:workhorse@localhost:5432/workhorse_demo
+      DATABASE_URL_TEST_PACKED: postgres://workhorse:workhorse@localhost:5432/workhorse_test_packed
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -80,6 +81,7 @@ jobs:
         run: grep -q "^## ${GITHUB_REF_NAME#v} " CHANGELOG.md
 
       - run: pnpm db:reset:test
+      - run: pnpm db:reset:test-packed
       - run: pnpm check
 
       - name: Pack the publishable packages

--- a/typescript/core/test/support-matrix.test.ts
+++ b/typescript/core/test/support-matrix.test.ts
@@ -342,8 +342,12 @@ describe("continuous integration", () => {
     ]) {
       const workflow = await read(workflowPath);
       expect(workflow).toContain("image: postgres:18-alpine");
+      expect(workflow).toContain(
+        "DATABASE_URL_TEST_PACKED: postgres://workhorse:workhorse@localhost:5432/workhorse_test_packed",
+      );
       expect(workflow).toContain("sudo apt-get install --yes postgresql-client-18");
       expect(workflow).toContain('echo "/usr/lib/postgresql/18/bin" >> "$GITHUB_PATH"');
+      expect(workflow).toContain("- run: pnpm db:reset:test-packed");
     }
   });
 


### PR DESCRIPTION
Fix the third WH-430 rehearsal blocker. Both dry runs passed the PostgreSQL client boundary, then failed because the full release gate lacked DATABASE_URL_TEST_PACKED.

- provide the packed database URL to both release build jobs
- reset the packed database in the npm release workflow before pnpm check
- require both conditions in the workflow contract test

Verification:
- pnpm exec vitest run typescript/core/test/support-matrix.test.ts
- pre-commit core typecheck and changed-scope tests
- pnpm exec oxfmt --check on changed files