### PR TITLE
[WH-430] Provision the release demo database

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -37,6 +37,7 @@ jobs:
           --health-timeout 5s
           --health-retries 20
     env:
+      DATABASE_URL_PRIMARY: postgres://workhorse:workhorse@localhost:5432/workhorse_dev_primary
       WORKHORSE_TEST_DATABASE_URL: postgres://workhorse:workhorse@localhost:5432/workhorse_test
       WORKHORSE_DEMO_DATABASE_URL: postgres://workhorse:workhorse@localhost:5432/workhorse_demo
       DATABASE_URL_TEST_PACKED: postgres://workhorse:workhorse@localhost:5432/workhorse_test_packed
@@ -64,6 +65,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/python/v')
         run: pnpm release:check python $GITHUB_REF_NAME
 
+      - run: pnpm db:reset:dev-primary
       - run: pnpm db:reset:test
       - run: pnpm db:reset:test-packed
       - run: pnpm check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
           --health-timeout 5s
           --health-retries 20
     env:
+      DATABASE_URL_PRIMARY: postgres://workhorse:workhorse@localhost:5432/workhorse_dev_primary
       WORKHORSE_TEST_DATABASE_URL: postgres://workhorse:workhorse@localhost:5432/workhorse_test
       WORKHORSE_DEMO_DATABASE_URL: postgres://workhorse:workhorse@localhost:5432/workhorse_demo
       DATABASE_URL_TEST_PACKED: postgres://workhorse:workhorse@localhost:5432/workhorse_test_packed
@@ -80,6 +81,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: grep -q "^## ${GITHUB_REF_NAME#v} " CHANGELOG.md
 
+      - run: pnpm db:reset:dev-primary
       - run: pnpm db:reset:test
       - run: pnpm db:reset:test-packed
       - run: pnpm check

--- a/typescript/core/test/support-matrix.test.ts
+++ b/typescript/core/test/support-matrix.test.ts
@@ -343,10 +343,14 @@ describe("continuous integration", () => {
       const workflow = await read(workflowPath);
       expect(workflow).toContain("image: postgres:18-alpine");
       expect(workflow).toContain(
+        "DATABASE_URL_PRIMARY: postgres://workhorse:workhorse@localhost:5432/workhorse_dev_primary",
+      );
+      expect(workflow).toContain(
         "DATABASE_URL_TEST_PACKED: postgres://workhorse:workhorse@localhost:5432/workhorse_test_packed",
       );
       expect(workflow).toContain("sudo apt-get install --yes postgresql-client-18");
       expect(workflow).toContain('echo "/usr/lib/postgresql/18/bin" >> "$GITHUB_PATH"');
+      expect(workflow).toContain("- run: pnpm db:reset:dev-primary");
       expect(workflow).toContain("- run: pnpm db:reset:test-packed");
     }
   });


### PR DESCRIPTION
The exact-candidate npm and Python dry runs both reached test:demo-smoke, then failed because the release jobs had not provisioned workhorse_dev_primary before starting the clean demo. This gives both release build jobs the same DATABASE_URL_PRIMARY and reset step used by the demo smoke CI lane, with a workflow contract regression test.\n\nVerification: pnpm exec vitest run typescript/core/test/support-matrix.test.ts (40 passed); pre-commit core typecheck and changed-scope tests passed.