### PR TITLE
WH-256 Prepare Python 0.1.0b2 provenance fix

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -92,4 +92,7 @@ jobs:
         with:
           name: python-distributions
           path: python/dist
-      - run: uv publish --trusted-publishing always python/dist/*
+      - uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6
+        with:
+          paths: python/dist/*
+      - run: uv publish --trusted-publishing always python/dist/*.whl python/dist/*.tar.gz

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -148,6 +148,7 @@ The Python package releases independently from a `python/vX.Y.Z` tag. The tag mu
 `python/pyproject.toml` and a heading in `python/CHANGELOG.md`. `.github/workflows/release-python.yml`
 runs `pnpm check`, then uv builds a source distribution and universal wheel. A separate `pypi`
 environment publishes those artifacts through PyPI trusted publishing with `id-token: write`.
+Before publication, the publish job generates a PEP 740 attestation beside each distribution.
 
 The Go module releases independently from a `go/vX.Y.Z` tag. `scripts/release-go.sh X.Y.Z` requires
 a clean worktree and a matching `go/CHANGELOG.md` heading. It resets the test database, runs
@@ -200,7 +201,8 @@ a staged release rather than a concurrent one:
 2. Download and inspect every npm and Python archive. Install all eight npm tarballs, the Python
    wheel, and the Python source distribution in clean consumers. Build the Go external consumer
    from the same commit. Test registries are not part of the rehearsal.
-3. Publish Python first. Verify `0.1.0b1` through PyPI before continuing.
+3. Publish Python first. `0.1.0b1` remains public without provenance. Verify the fix-forward
+   `0.1.0b2` release through PyPI before continuing.
 4. Publish npm second. Publish `@stablemates/workhorse` before its seven peer dependents, and verify
    every `0.1.0-beta.1` package before continuing.
 5. Publish Go last. Verify `go/v0.1.0-beta.1` through the public module proxy.
@@ -238,7 +240,8 @@ pipeline.
 1. Update `python/pyproject.toml` and add the same version to `python/CHANGELOG.md`.
 2. Tag `python/vX.Y.Z`. `pnpm release:check` refuses a mismatched or undocumented version.
 3. `pnpm check` runs before uv builds either distribution artifact.
-4. The `pypi` environment publishes the downloaded artifacts through trusted publishing.
+4. The `pypi` environment generates PEP 740 attestations for the downloaded artifacts, then
+   publishes both distributions and their attestations through trusted publishing.
 
 ### Go module
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,7 +6,14 @@ releases independently from the TypeScript packages and the Go module.
 Workhorse is a public beta. Any 0.x minor release may break compatibility, including the schema.
 There is no upgrade path between 0.x releases; ordered migrations begin at 1.0.0.
 
-## 0.1.0b1 — unreleased
+## 0.1.0b2 — unreleased
+
+### Fixed
+
+- The fix-forward release includes PEP 740 attestations for its wheel and source distribution.
+  The package behavior is unchanged from `0.1.0b1`.
+
+## 0.1.0b1 — 2026-08-31
 
 ### Changed
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "stablemates-workhorse"
-version = "0.1.0b1"
+version = "0.1.0b2"
 description = "Public beta Python SDK for the Workhorse PostgreSQL durable execution protocol"
 readme = "README.md"
 license = "Apache-2.0"

--- a/python/tests/test_release.py
+++ b/python/tests/test_release.py
@@ -61,7 +61,7 @@ def test_python_support_contract_matches_repository_declarations(database_url: s
     assert project["optional-dependencies"]["psycopg"] == []
     assert project["optional-dependencies"]["asyncpg"] == ["asyncpg>=0.31,<1"]
     assert project["name"] == "stablemates-workhorse"
-    assert project["version"] == "0.1.0b1"
+    assert project["version"] == "0.1.0b2"
     assert "Development Status :: 4 - Beta" in project["classifiers"]
 
     postgres_majors = [str(major) for major in support["postgres"]["tested"]]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1001,7 +1001,7 @@ wheels = [
 
 [[package]]
 name = "stablemates-workhorse"
-version = "0.1.0b1"
+version = "0.1.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },

--- a/scripts/check-release.test.ts
+++ b/scripts/check-release.test.ts
@@ -3,12 +3,12 @@ import { checkRelease } from "./check-release.js";
 
 describe("checkRelease", () => {
   it("accepts the Python manifest version when its changelog documents the release", async () => {
-    await expect(checkRelease("python", "python/v0.1.0b1")).resolves.toBeUndefined();
+    await expect(checkRelease("python", "python/v0.1.0b2")).resolves.toBeUndefined();
   });
 
   it("rejects a Python tag that disagrees with the package manifest", async () => {
     await expect(checkRelease("python", "python/v9.9.9")).rejects.toThrow(
-      "python/pyproject.toml is 0.1.0b1 but the tag is 9.9.9",
+      "python/pyproject.toml is 0.1.0b2 but the tag is 9.9.9",
     );
   });
 

--- a/scripts/public-beta-release.test.ts
+++ b/scripts/public-beta-release.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { publishedPackages, repositoryRoot } from "./packages.js";
 
 const npmVersion = "0.1.0-beta.1";
-const pythonVersion = "0.1.0b1";
+const pythonVersion = "0.1.0b2";
 const betaLabel = "public beta";
 const compatibilityNotice = "There is no upgrade path between 0.x releases";
 

--- a/site/content/docs/compatibility.mdx
+++ b/site/content/docs/compatibility.mdx
@@ -95,9 +95,10 @@ dashboard contracts, and exported types describe the same source revision. The
 [changelog](https://github.com/stablemates/workhorse/blob/main/CHANGELOG.md) records breaking
 changes and the schema version each release requires.
 
-The first public beta is `0.1.0-beta.1` for npm and Go, and `0.1.0b1` for Python. Any 0.x minor
-release may break compatibility, including the schema. There is no upgrade path between 0.x
-releases; ordered migrations begin at 1.0.0.
+The first public beta is `0.1.0-beta.1` for npm and Go, and `0.1.0b1` for Python. Python
+`0.1.0b2` is the fix-forward release with verifiable provenance. Any 0.x minor release may break
+compatibility, including the schema. There is no upgrade path between 0.x releases; ordered
+migrations begin at 1.0.0.
 
 The dashboard and core may use different patch releases within the same minor line. The dashboard
 server reads core-owned versioned views and functions, so a core patch remains compatible when its
@@ -105,7 +106,8 @@ migration preserves those contracts.
 
 `stablemates-workhorse` releases from its own `python/vX.Y.Z` tag after its format, lint, type, test, packed,
 and site lanes pass. Its tag must match `python/pyproject.toml` and `python/CHANGELOG.md`. The release
-builds a source distribution and universal wheel, then PyPI trusted publishing uploads both.
+builds a source distribution and universal wheel, generates PEP 740 attestations for both, then
+PyPI trusted publishing uploads the files and attestations.
 
 The Go module records independent versions in `go/CHANGELOG.md`. The repository release script
 runs the full gate before it creates and pushes the matching `go/vX.Y.Z` tag.

--- a/site/content/docs/installation.mdx
+++ b/site/content/docs/installation.mdx
@@ -36,7 +36,7 @@ Install the SDK. Each package includes its default PostgreSQL driver.
   <Tab value="Python">
 
     ```bash
-    pip install stablemates-workhorse==0.1.0b1
+    pip install stablemates-workhorse==0.1.0b2
     ```
 
     Use the `asyncpg` extra when that is your application's driver instead of Psycopg.

--- a/site/content/docs/quickstart.mdx
+++ b/site/content/docs/quickstart.mdx
@@ -21,7 +21,7 @@ connection string.
   <Tab value="Python">
 
     ```bash
-    pip install stablemates-workhorse==0.1.0b1
+    pip install stablemates-workhorse==0.1.0b2
     ```
 
   </Tab>

--- a/site/src/routes/index.tsx
+++ b/site/src/routes/index.tsx
@@ -525,7 +525,7 @@ function BetaMark() {
 function InstallCommands() {
   const commands = [
     ["npm", "npm install @stablemates/workhorse@0.1.0-beta.1"],
-    ["python", "pip install stablemates-workhorse==0.1.0b1"],
+    ["python", "pip install stablemates-workhorse==0.1.0b2"],
     ["go", "go get github.com/stablemates/workhorse/go@v0.1.0-beta.1"],
   ] as const;
 

--- a/typescript/core/test/support-matrix.test.ts
+++ b/typescript/core/test/support-matrix.test.ts
@@ -306,7 +306,12 @@ describe("continuous integration", () => {
     expect(workflow).toContain("needs: build");
     expect(workflow).toContain("environment: pypi");
     expect(workflow).toContain("id-token: write");
-    expect(workflow).toContain("uv publish --trusted-publishing always");
+    const attest = "astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6";
+    const publish = "uv publish --trusted-publishing always python/dist/*.whl python/dist/*.tar.gz";
+    expect(workflow).toContain(attest);
+    expect(workflow).toContain("paths: python/dist/*");
+    expect(workflow).toContain(publish);
+    expect(workflow.indexOf(attest)).toBeLessThan(workflow.indexOf(publish));
   });
 
   it("creates Go module tags only after the release check and full repository gate", async () => {


### PR DESCRIPTION
## Summary

- generate PEP 740 attestations before the protected PyPI publish step
- bump the Python fix-forward release to 0.1.0b2 without changing package behavior
- update release checks, install surfaces, changelog, and compatibility documentation

## Verification

- release check for python/v0.1.0b2
- 50 targeted release and support-matrix tests
- 54 Python unit tests
- Python lint and strict type checks
- site type check
- uv lock check and wheel/source distribution build