### PR TITLE
WH-256 Upload Python publish attestations

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -95,4 +95,4 @@ jobs:
       - uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6
         with:
           paths: python/dist/*
-      - run: uv publish --trusted-publishing always python/dist/*.whl python/dist/*.tar.gz
+      - run: uv publish --trusted-publishing always python/dist/*

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -201,8 +201,8 @@ a staged release rather than a concurrent one:
 2. Download and inspect every npm and Python archive. Install all eight npm tarballs, the Python
    wheel, and the Python source distribution in clean consumers. Build the Go external consumer
    from the same commit. Test registries are not part of the rehearsal.
-3. Publish Python first. `0.1.0b1` remains public without provenance. Verify the fix-forward
-   `0.1.0b2` release through PyPI before continuing.
+3. Publish Python first. `0.1.0b1` and `0.1.0b2` remain public without provenance. Verify the
+   fix-forward `0.1.0b3` release through PyPI before continuing.
 4. Publish npm second. Publish `@stablemates/workhorse` before its seven peer dependents, and verify
    every `0.1.0-beta.1` package before continuing.
 5. Publish Go last. Verify `go/v0.1.0-beta.1` through the public module proxy.

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,11 +6,18 @@ releases independently from the TypeScript packages and the Go module.
 Workhorse is a public beta. Any 0.x minor release may break compatibility, including the schema.
 There is no upgrade path between 0.x releases; ordered migrations begin at 1.0.0.
 
-## 0.1.0b2 — unreleased
+## 0.1.0b3 — unreleased
 
 ### Fixed
 
-- The fix-forward release includes PEP 740 attestations for its wheel and source distribution.
+- The fix-forward release uploads PEP 740 attestations with its wheel and source distribution.
+  The package behavior is unchanged from `0.1.0b1`.
+
+## 0.1.0b2 — 2026-08-31
+
+### Fixed
+
+- The release workflow generated PEP 740 attestations but omitted them from the PyPI upload.
   The package behavior is unchanged from `0.1.0b1`.
 
 ## 0.1.0b1 — 2026-08-31

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "stablemates-workhorse"
-version = "0.1.0b2"
+version = "0.1.0b3"
 description = "Public beta Python SDK for the Workhorse PostgreSQL durable execution protocol"
 readme = "README.md"
 license = "Apache-2.0"

--- a/python/tests/test_release.py
+++ b/python/tests/test_release.py
@@ -61,7 +61,7 @@ def test_python_support_contract_matches_repository_declarations(database_url: s
     assert project["optional-dependencies"]["psycopg"] == []
     assert project["optional-dependencies"]["asyncpg"] == ["asyncpg>=0.31,<1"]
     assert project["name"] == "stablemates-workhorse"
-    assert project["version"] == "0.1.0b2"
+    assert project["version"] == "0.1.0b3"
     assert "Development Status :: 4 - Beta" in project["classifiers"]
 
     postgres_majors = [str(major) for major in support["postgres"]["tested"]]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1001,7 +1001,7 @@ wheels = [
 
 [[package]]
 name = "stablemates-workhorse"
-version = "0.1.0b2"
+version = "0.1.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },

--- a/scripts/check-release.test.ts
+++ b/scripts/check-release.test.ts
@@ -3,12 +3,12 @@ import { checkRelease } from "./check-release.js";
 
 describe("checkRelease", () => {
   it("accepts the Python manifest version when its changelog documents the release", async () => {
-    await expect(checkRelease("python", "python/v0.1.0b2")).resolves.toBeUndefined();
+    await expect(checkRelease("python", "python/v0.1.0b3")).resolves.toBeUndefined();
   });
 
   it("rejects a Python tag that disagrees with the package manifest", async () => {
     await expect(checkRelease("python", "python/v9.9.9")).rejects.toThrow(
-      "python/pyproject.toml is 0.1.0b2 but the tag is 9.9.9",
+      "python/pyproject.toml is 0.1.0b3 but the tag is 9.9.9",
     );
   });
 

--- a/scripts/public-beta-release.test.ts
+++ b/scripts/public-beta-release.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { publishedPackages, repositoryRoot } from "./packages.js";
 
 const npmVersion = "0.1.0-beta.1";
-const pythonVersion = "0.1.0b2";
+const pythonVersion = "0.1.0b3";
 const betaLabel = "public beta";
 const compatibilityNotice = "There is no upgrade path between 0.x releases";
 

--- a/site/content/docs/compatibility.mdx
+++ b/site/content/docs/compatibility.mdx
@@ -96,9 +96,9 @@ dashboard contracts, and exported types describe the same source revision. The
 changes and the schema version each release requires.
 
 The first public beta is `0.1.0-beta.1` for npm and Go, and `0.1.0b1` for Python. Python
-`0.1.0b2` is the fix-forward release with verifiable provenance. Any 0.x minor release may break
-compatibility, including the schema. There is no upgrade path between 0.x releases; ordered
-migrations begin at 1.0.0.
+`0.1.0b1` and `0.1.0b2` remain public without provenance. Python `0.1.0b3` is the fix-forward
+release with verifiable provenance. Any 0.x minor release may break compatibility, including the
+schema. There is no upgrade path between 0.x releases; ordered migrations begin at 1.0.0.
 
 The dashboard and core may use different patch releases within the same minor line. The dashboard
 server reads core-owned versioned views and functions, so a core patch remains compatible when its

--- a/site/content/docs/installation.mdx
+++ b/site/content/docs/installation.mdx
@@ -36,7 +36,7 @@ Install the SDK. Each package includes its default PostgreSQL driver.
   <Tab value="Python">
 
     ```bash
-    pip install stablemates-workhorse==0.1.0b2
+    pip install stablemates-workhorse==0.1.0b3
     ```
 
     Use the `asyncpg` extra when that is your application's driver instead of Psycopg.

--- a/site/content/docs/quickstart.mdx
+++ b/site/content/docs/quickstart.mdx
@@ -21,7 +21,7 @@ connection string.
   <Tab value="Python">
 
     ```bash
-    pip install stablemates-workhorse==0.1.0b2
+    pip install stablemates-workhorse==0.1.0b3
     ```
 
   </Tab>

--- a/site/src/routes/index.tsx
+++ b/site/src/routes/index.tsx
@@ -525,7 +525,7 @@ function BetaMark() {
 function InstallCommands() {
   const commands = [
     ["npm", "npm install @stablemates/workhorse@0.1.0-beta.1"],
-    ["python", "pip install stablemates-workhorse==0.1.0b2"],
+    ["python", "pip install stablemates-workhorse==0.1.0b3"],
     ["go", "go get github.com/stablemates/workhorse/go@v0.1.0-beta.1"],
   ] as const;
 

--- a/typescript/core/test/support-matrix.test.ts
+++ b/typescript/core/test/support-matrix.test.ts
@@ -307,10 +307,11 @@ describe("continuous integration", () => {
     expect(workflow).toContain("environment: pypi");
     expect(workflow).toContain("id-token: write");
     const attest = "astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6";
-    const publish = "uv publish --trusted-publishing always python/dist/*.whl python/dist/*.tar.gz";
+    const publish = "uv publish --trusted-publishing always python/dist/*";
     expect(workflow).toContain(attest);
     expect(workflow).toContain("paths: python/dist/*");
     expect(workflow).toContain(publish);
+    expect(workflow).not.toContain("python/dist/*.whl python/dist/*.tar.gz");
     expect(workflow.indexOf(attest)).toBeLessThan(workflow.indexOf(publish));
   });
 


### PR DESCRIPTION
Fixes the attestation handoff discovered during the 0.1.0b2 release. The workflow now passes the complete distribution directory to uv publish so generated PEP 740 sidecars are uploaded with their distributions. Prepares 0.1.0b3 because published versions are immutable.\n\nVerification: targeted release tests, Python release metadata tests, Python build, and pre-commit checks passed.