### PR TITLE
WH-512 Focus the Python release gate

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -1,8 +1,6 @@
 # Builds and publishes the independently-versioned Python distribution from python/vX.Y.Z tags.
-#
-# GitHub Actions remain disabled while this repository is private. This definition is ready for
-# that restriction to be lifted, but it must not be dispatched until then. The build job carries
-# no publication identity; only the separate PyPI environment can mint the trusted-publisher token.
+# The build job validates only Python and the dashboard assets embedded in its distributions. It
+# carries no publication identity; only the PyPI environment can mint the publisher token.
 name: Release Python
 
 on:
@@ -16,19 +14,20 @@ on:
         default: true
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     services:
       postgres:
         image: postgres:18-alpine
         env:
           POSTGRES_USER: workhorse
           POSTGRES_PASSWORD: workhorse
-          POSTGRES_DB: workhorse_dev
+          POSTGRES_DB: workhorse_test
         ports:
           - 5432:5432
         options: >-
@@ -37,39 +36,28 @@ jobs:
           --health-timeout 5s
           --health-retries 20
     env:
-      DATABASE_URL_PRIMARY: postgres://workhorse:workhorse@localhost:5432/workhorse_dev_primary
-      WORKHORSE_TEST_DATABASE_URL: postgres://workhorse:workhorse@localhost:5432/workhorse_test
-      WORKHORSE_DEMO_DATABASE_URL: postgres://workhorse:workhorse@localhost:5432/workhorse_demo
-      DATABASE_URL_TEST_PACKED: postgres://workhorse:workhorse@localhost:5432/workhorse_test_packed
+      DATABASE_URL_TEST: postgres://workhorse:workhorse@localhost:5432/workhorse_test
     steps:
+      - name: Require successful main CI for this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          successful_runs="$(gh api \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs?head_sha=$GITHUB_SHA&event=push&status=completed&per_page=10" \
+            --jq '[.workflow_runs[] | select(.conclusion == "success")] | length')"
+          if [ "$successful_runs" -eq 0 ]; then
+            echo "No successful main CI push run exists for $GITHUB_SHA" >&2
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: go/go.mod
       - uses: astral-sh/setup-uv@v9.0.0
-      - name: Install matching PostgreSQL client
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes postgresql-common
-          sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
-          sudo apt-get install --yes postgresql-client-18
-          echo "/usr/lib/postgresql/18/bin" >> "$GITHUB_PATH"
       - run: pnpm install --frozen-lockfile
-
-      - name: Check the tag against the Python version and changelog
-        if: startsWith(github.ref, 'refs/tags/python/v')
-        run: pnpm release:check python $GITHUB_REF_NAME
-
-      - run: pnpm db:reset:dev-primary
-      - run: pnpm db:reset:test
-      - run: pnpm db:reset:test-packed
-      - run: pnpm check
-      - run: uv build --project python
+      - run: pnpm python:release-check
 
       - uses: actions/upload-artifact@v4
         with:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -189,7 +189,8 @@ and exercise external module consumers before a release can create the module ta
 
 ## Release process
 
-Every release is a tag, and every tag runs the full check suite before anything is published.
+Every release is a tag that points to a green public CI commit. Each tag then runs the focused gate
+for the distribution being published.
 
 ### First public beta release train
 
@@ -238,9 +239,11 @@ pipeline.
 ### Python distribution
 
 1. Update `python/pyproject.toml` and add the same version to `python/CHANGELOG.md`.
-2. Tag `python/vX.Y.Z`. `pnpm release:check` refuses a mismatched or undocumented version.
-3. `pnpm check` runs before uv builds either distribution artifact.
-4. The `pypi` environment generates PEP 740 attestations for the downloaded artifacts, then
+2. Tag `python/vX.Y.Z`. The workflow requires a successful `main` CI push run for that commit.
+3. `pnpm python:release-check` validates the version and changelog, rebuilds the embedded dashboard
+   bundle, checks Python format, lint, types, and dependencies, then runs every Python test against
+   PostgreSQL. It builds the wheel and source distribution once and tests those exact files.
+4. The `pypi` environment generates PEP 740 attestations for the unchanged artifacts, then
    publishes both distributions and their attestations through trusted publishing.
 
 ### Go module
@@ -249,11 +252,9 @@ pipeline.
 2. Run `scripts/release-go.sh X.Y.Z` from a clean worktree.
 3. The script runs `pnpm check`, creates `go/vX.Y.Z`, and pushes the tag only after the gate passes.
 
-GitHub Actions remain disabled while the repository is private. These definitions must not be
-dispatched, and release tags must not be pushed, until that restriction is lifted. When the
-repository becomes public, its `main` ruleset must require pull requests and `CI / required`.
-Outside collaborators require workflow approval. The protected `npm` and `pypi` environments
-must prevent self-approval and administrator bypass.
+The public repository requires pull requests and `CI / required` on `main`. Outside collaborators
+require workflow approval. The protected `npm` and `pypi` environments require review and prevent
+administrator bypass.
 
 ## Benchmark validation is not the support boundary
 

--- a/docs/decisions/0043-public-ci-and-release-policy.md
+++ b/docs/decisions/0043-public-ci-and-release-policy.md
@@ -47,6 +47,13 @@ gate remains usable. Manual dispatches build and validate artifacts but never pu
 Maintainers create release tags; repository rules must prevent other actors from creating or
 updating them.
 
+The Python workflow first requires a successful `main` push CI run for the tagged commit. Its
+focused release gate checks the Python version contract, embedded dashboard bundle, format, lint,
+types, dependencies, and complete test suite against PostgreSQL. It builds the wheel and source
+distribution once, tests those exact files in clean consumers, and passes the unchanged artifacts
+to the protected publication job. Go, TypeScript database, documentation, parity, site, and demo
+checks remain merge gates in CI and do not run again during Python publication.
+
 Go stays local through `scripts/release-go.sh`. A Go module becomes public when its tag is pushed,
 so a workflow triggered by that tag cannot gate publication. The script runs the full release gate
 before it creates and pushes the annotated tag.

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "format": "oxfmt --write . && pnpm python:format && pnpm go:fmt",
     "format:check": "oxfmt --check . && pnpm python:format:check && pnpm go:fmt:check",
     "python:build": "pnpm dashboard-bundle:fetch && uv build --project python",
+    "python:release-check": "tsx scripts/check-python-release.ts",
     "python:format": "uv run --project python ruff format python/src python/tests python/examples",
     "python:format:check": "uv run --project python ruff format --check python/src python/tests python/examples",
     "python:lint": "uv run --project python ruff check python/src python/tests python/examples",

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -26,19 +26,25 @@ def installed_distribution_interpreters(
     tmp_path_factory: pytest.TempPathFactory,
 ) -> dict[str, Path]:
     scratch = tmp_path_factory.mktemp("python-distributions")
-    distribution_directory = scratch / "dist"
-    subprocess.run(
-        [
-            "uv",
-            "build",
-            "--project",
-            str(REPOSITORY / "python"),
-            "--out-dir",
-            str(distribution_directory),
-        ],
-        check=True,
-        cwd=REPOSITORY,
-    )
+    configured_distributions = os.environ.get("WORKHORSE_PYTHON_DISTRIBUTIONS")
+    if configured_distributions:
+        distribution_directory = Path(configured_distributions)
+        if not distribution_directory.is_absolute():
+            distribution_directory = REPOSITORY / distribution_directory
+    else:
+        distribution_directory = scratch / "dist"
+        subprocess.run(
+            [
+                "uv",
+                "build",
+                "--project",
+                str(REPOSITORY / "python"),
+                "--out-dir",
+                str(distribution_directory),
+            ],
+            check=True,
+            cwd=REPOSITORY,
+        )
     artifacts = {
         "wheel": next(distribution_directory.glob("*.whl")),
         "sdist": next(distribution_directory.glob("*.tar.gz")),

--- a/scripts/check-python-release.ts
+++ b/scripts/check-python-release.ts
@@ -1,0 +1,104 @@
+import { spawn } from "node:child_process";
+import { cp, mkdir, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { checkRelease } from "./check-release.js";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "..");
+const releaseDirectory = path.join(repositoryRoot, "python", "dist");
+
+async function run(
+  command: string,
+  args: readonly string[],
+  environment: Readonly<Record<string, string>> = {},
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, [...args], {
+      cwd: repositoryRoot,
+      env: { ...process.env, ...environment },
+      stdio: "inherit",
+    });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${command} ${args.join(" ")} exited with ${signal ?? String(code)}`));
+    });
+  });
+}
+
+async function pythonVersion(): Promise<string> {
+  const manifest = await readFile(path.join(repositoryRoot, "python", "pyproject.toml"), "utf8");
+  const version = /^version = "([^"]+)"$/m.exec(manifest)?.[1];
+  if (!version) throw new Error("python/pyproject.toml declares no project version");
+  return version;
+}
+
+function releaseTag(version: string): string {
+  const requested = process.argv[2];
+  if (requested) return requested;
+  if (process.env.GITHUB_REF_TYPE === "tag") {
+    const githubTag = process.env.GITHUB_REF_NAME;
+    if (!githubTag) throw new Error("GITHUB_REF_TYPE is tag but GITHUB_REF_NAME is missing");
+    return githubTag;
+  }
+  return `python/v${version}`;
+}
+
+async function distributions(directory: string, version: string): Promise<readonly string[]> {
+  const files = (await readdir(directory, { withFileTypes: true }))
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .toSorted();
+  const names = files.filter((name) => name.endsWith(".whl") || name.endsWith(".tar.gz"));
+  const unexpected = files.filter((name) => name !== ".gitignore" && !names.includes(name));
+  if (unexpected.length > 0) {
+    throw new Error(`Unexpected files in the Python build output: ${unexpected.join(", ")}`);
+  }
+  const expected = [
+    `stablemates_workhorse-${version}-py3-none-any.whl`,
+    `stablemates_workhorse-${version}.tar.gz`,
+  ].toSorted();
+  if (JSON.stringify(names) !== JSON.stringify(expected)) {
+    throw new Error(
+      `Expected exactly ${expected.join(", ")}; built ${names.join(", ") || "no distributions"}`,
+    );
+  }
+  return names;
+}
+
+export async function checkPythonRelease(): Promise<void> {
+  const version = await pythonVersion();
+  await checkRelease("python", releaseTag(version));
+
+  await run("pnpm", ["dashboard-bundle:check"]);
+  await run("pnpm", ["python:format:check"]);
+  await run("pnpm", ["python:lint"]);
+  await run("pnpm", ["python:vuln"]);
+  await run("pnpm", ["python:typecheck"]);
+  await run("pnpm", ["dashboard-bundle:fetch"]);
+
+  const temporary = await mkdtemp(path.join(tmpdir(), "workhorse-python-release-"));
+  const stagedDistributions = path.join(temporary, "dist");
+  try {
+    await run("uv", ["build", "--project", "python", "--out-dir", stagedDistributions]);
+    const names = await distributions(stagedDistributions, version);
+    await run("pnpm", ["python:test"], {
+      WORKHORSE_PYTHON_DISTRIBUTIONS: stagedDistributions,
+    });
+
+    await rm(releaseDirectory, { force: true, recursive: true });
+    await mkdir(releaseDirectory, { recursive: true });
+    await Promise.all(
+      names.map((name) =>
+        cp(path.join(stagedDistributions, name), path.join(releaseDirectory, name)),
+      ),
+    );
+    process.stdout.write(`Verified Python ${version} and wrote ${names.join(", ")}\n`);
+  } finally {
+    await rm(temporary, { force: true, recursive: true });
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  await checkPythonRelease();
+}

--- a/site/content/docs/compatibility.mdx
+++ b/site/content/docs/compatibility.mdx
@@ -104,10 +104,11 @@ The dashboard and core may use different patch releases within the same minor li
 server reads core-owned versioned views and functions, so a core patch remains compatible when its
 migration preserves those contracts.
 
-`stablemates-workhorse` releases from its own `python/vX.Y.Z` tag after its format, lint, type, test, packed,
-and site lanes pass. Its tag must match `python/pyproject.toml` and `python/CHANGELOG.md`. The release
-builds a source distribution and universal wheel, generates PEP 740 attestations for both, then
-PyPI trusted publishing uploads the files and attestations.
+`stablemates-workhorse` releases from its own `python/vX.Y.Z` tag after the tagged commit passes
+public CI. Its focused release gate checks the version, embedded dashboard bundle, Python format,
+lint, types, dependencies, and complete PostgreSQL-backed test suite. It builds and tests a source
+distribution and universal wheel once, generates PEP 740 attestations for those files, then PyPI
+trusted publishing uploads the unchanged files and attestations.
 
 The Go module records independent versions in `go/CHANGELOG.md`. The repository release script
 runs the full gate before it creates and pushes the matching `go/vX.Y.Z` tag.

--- a/typescript/core/test/support-matrix.test.ts
+++ b/typescript/core/test/support-matrix.test.ts
@@ -297,12 +297,25 @@ describe("continuous integration", () => {
 
   it("publishes Python distributions from a checked, versioned tag", async () => {
     const workflow = await read(".github/workflows/release-python.yml");
+    const releaseCheck = await read("scripts/check-python-release.ts");
 
     expect(workflow).toContain('tags: ["python/v*"]');
-    expect(workflow).toContain("pnpm release:check python $GITHUB_REF_NAME");
-    expect(workflow).toContain("pnpm db:reset:test-packed");
-    expect(workflow).toContain("pnpm check");
-    expect(workflow).toContain("uv build --project python");
+    expect(workflow).toContain("actions: read");
+    expect(workflow).toContain("actions/workflows/ci.yml/runs?head_sha=$GITHUB_SHA");
+    expect(workflow).toContain("DATABASE_URL_TEST:");
+    expect(workflow).toContain("pnpm python:release-check");
+    expect(workflow).not.toContain("pnpm check");
+    expect(workflow).not.toContain("actions/setup-go");
+    expect(workflow).not.toContain("DATABASE_URL_TEST_PACKED");
+    expect(releaseCheck).toContain('checkRelease("python", releaseTag(version))');
+    expect(releaseCheck).toContain('["dashboard-bundle:check"]');
+    expect(releaseCheck).toContain('["python:format:check"]');
+    expect(releaseCheck).toContain('["python:lint"]');
+    expect(releaseCheck).toContain('["python:vuln"]');
+    expect(releaseCheck).toContain('["python:typecheck"]');
+    expect(releaseCheck).toContain('["python:test"]');
+    expect(releaseCheck).toContain("WORKHORSE_PYTHON_DISTRIBUTIONS: stagedDistributions");
+    expect(releaseCheck).toContain('["build", "--project", "python", "--out-dir"');
     expect(workflow).toContain("needs: build");
     expect(workflow).toContain("environment: pypi");
     expect(workflow).toContain("id-token: write");
@@ -329,36 +342,38 @@ describe("continuous integration", () => {
   });
 
   it("installs the non-Node toolchains before static and release checks", async () => {
-    for (const workflowPath of [
-      ".github/workflows/ci.yml",
-      ".github/workflows/release.yml",
-      ".github/workflows/release-python.yml",
-    ]) {
+    for (const workflowPath of [".github/workflows/ci.yml", ".github/workflows/release.yml"]) {
       const workflow = await read(workflowPath);
       expect(workflow).toContain("actions/setup-go@v7");
       expect(workflow).toContain("go-version-file: go/go.mod");
       expect(workflow).toContain("astral-sh/setup-uv@v9.0.0");
     }
+
+    const pythonRelease = await read(".github/workflows/release-python.yml");
+    expect(pythonRelease).toContain("astral-sh/setup-uv@v9.0.0");
+    expect(pythonRelease).not.toContain("actions/setup-go");
   });
 
   it("installs a PostgreSQL client that matches the release service", async () => {
-    for (const workflowPath of [
-      ".github/workflows/release.yml",
-      ".github/workflows/release-python.yml",
-    ]) {
-      const workflow = await read(workflowPath);
-      expect(workflow).toContain("image: postgres:18-alpine");
-      expect(workflow).toContain(
-        "DATABASE_URL_PRIMARY: postgres://workhorse:workhorse@localhost:5432/workhorse_dev_primary",
-      );
-      expect(workflow).toContain(
-        "DATABASE_URL_TEST_PACKED: postgres://workhorse:workhorse@localhost:5432/workhorse_test_packed",
-      );
-      expect(workflow).toContain("sudo apt-get install --yes postgresql-client-18");
-      expect(workflow).toContain('echo "/usr/lib/postgresql/18/bin" >> "$GITHUB_PATH"');
-      expect(workflow).toContain("- run: pnpm db:reset:dev-primary");
-      expect(workflow).toContain("- run: pnpm db:reset:test-packed");
-    }
+    const npmRelease = await read(".github/workflows/release.yml");
+    expect(npmRelease).toContain("image: postgres:18-alpine");
+    expect(npmRelease).toContain(
+      "DATABASE_URL_PRIMARY: postgres://workhorse:workhorse@localhost:5432/workhorse_dev_primary",
+    );
+    expect(npmRelease).toContain(
+      "DATABASE_URL_TEST_PACKED: postgres://workhorse:workhorse@localhost:5432/workhorse_test_packed",
+    );
+    expect(npmRelease).toContain("sudo apt-get install --yes postgresql-client-18");
+    expect(npmRelease).toContain('echo "/usr/lib/postgresql/18/bin" >> "$GITHUB_PATH"');
+    expect(npmRelease).toContain("- run: pnpm db:reset:dev-primary");
+    expect(npmRelease).toContain("- run: pnpm db:reset:test-packed");
+
+    const pythonRelease = await read(".github/workflows/release-python.yml");
+    expect(pythonRelease).toContain("image: postgres:18-alpine");
+    expect(pythonRelease).toContain(
+      "DATABASE_URL_TEST: postgres://workhorse:workhorse@localhost:5432/workhorse_test",
+    );
+    expect(pythonRelease).not.toContain("postgresql-client-18");
   });
 
   it("benchmarks weekly on a supported PostgreSQL major under an explicit timeout", async () => {


### PR DESCRIPTION
## Summary

- require green main CI for the exact release commit
- replace duplicate monorepo checks with Python and embedded-dashboard checks
- build wheel and sdist once, test those exact files, and publish them unchanged
- run PostgreSQL-backed Python integration tests instead of skipping them

## Verification

- `pnpm python:release-check` — 150 passed
- pre-commit related scope — 103 files / 1008 tests passed
- Python lint, types, and unit scope passed
- core and site typechecks passed

Tracks WH-512.