### PR TITLE
WH-514 Isolate the npm catalogue check

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:protocol": "tsx scripts/with-env.ts node node_modules/vitest/vitest.mjs run --config vitest.database.config.ts typescript/core/test/sql-protocol-conformance.test.ts typescript/core/test/schema-migrations.test.ts",
     "sql-catalogues:generate": "tsx scripts/generate-sql-catalogues.ts",
     "sql-catalogues:check": "tsx scripts/generate-sql-catalogues.ts --check",
+    "sql-catalogues:check:typescript": "tsx scripts/generate-sql-catalogues.ts --check --typescript-only",
     "schema:generate": "tsx scripts/generate-clean-schema.ts",
     "parity:generate": "tsx scripts/generate-parity-tables.ts",
     "parity:check": "tsx scripts/generate-parity-tables.ts --check",

--- a/scripts/check-npm-release.ts
+++ b/scripts/check-npm-release.ts
@@ -44,7 +44,7 @@ export async function checkNpmRelease(): Promise<void> {
   if (!version) throw new Error("No publishable npm packages were found");
   await checkRelease("npm", releaseTag(version));
 
-  await run("pnpm", ["sql-catalogues:check"]);
+  await run("pnpm", ["sql-catalogues:check:typescript"]);
   await run("pnpm", ["dashboard-spec:check"]);
   await run("pnpm", ["npm:lint"]);
   await run("pnpm", ["npm:typecheck"]);

--- a/scripts/generate-sql-catalogues.ts
+++ b/scripts/generate-sql-catalogues.ts
@@ -28,6 +28,7 @@ type Manifest = {
 const repository = path.resolve(import.meta.dirname, "..");
 const manifestPath = path.join(repository, "protocol/v1/manifest.json");
 const check = process.argv.includes("--check");
+const typescriptOnly = process.argv.includes("--typescript-only");
 
 function arity(sql: string): number {
   return Math.max(0, ...Array.from(sql.matchAll(/\$(\d+)/g), (match) => Number(match[1])));
@@ -184,18 +185,26 @@ for (const statement of manifest.statements) {
     pythonBindings[statement.pythonBinding] = statement.name;
   }
 }
-const pythonSources = await readPythonSources();
-const pythonAccesses = findPythonStatementAccesses(pythonSources, path.join(repository, "python"));
-assertPythonStatementBindings(pythonBindings, names, pythonAccesses);
 if (check) await assertNoInlineTypeScriptSql();
-await Promise.all([
-  emit("go/sql_catalogue_generated.go", renderGo(manifest, manifest.statements)),
+const outputs = [
   emit(
     "typescript/core/src/queue/sql-catalogue.generated.ts",
     renderTypeScript(manifest, manifest.statements),
   ),
-  emit(
-    "python/src/workhorse/_statements.py",
-    renderPython(manifest, manifest.statements, pythonBindings),
-  ),
-]);
+];
+if (!typescriptOnly) {
+  const pythonSources = await readPythonSources();
+  const pythonAccesses = findPythonStatementAccesses(
+    pythonSources,
+    path.join(repository, "python"),
+  );
+  assertPythonStatementBindings(pythonBindings, names, pythonAccesses);
+  outputs.push(
+    emit("go/sql_catalogue_generated.go", renderGo(manifest, manifest.statements)),
+    emit(
+      "python/src/workhorse/_statements.py",
+      renderPython(manifest, manifest.statements, pythonBindings),
+    ),
+  );
+}
+await Promise.all(outputs);

--- a/typescript/core/test/support-matrix.test.ts
+++ b/typescript/core/test/support-matrix.test.ts
@@ -289,6 +289,7 @@ describe("continuous integration", () => {
   it("publishes exact npm tarballs through a focused gate with provenance", async () => {
     const workflow = await read(".github/workflows/release.yml");
     const releaseCheck = await read("scripts/check-npm-release.ts");
+    const scripts = (await readManifest("package.json")).scripts as Record<string, string>;
 
     expect(workflow).toContain('tags: ["v*"]');
     expect(workflow).toContain("actions: read");
@@ -299,7 +300,8 @@ describe("continuous integration", () => {
     expect(workflow).not.toContain("actions/setup-go");
     expect(workflow).not.toContain("astral-sh/setup-uv");
     expect(releaseCheck).toContain('checkRelease("npm", releaseTag(version))');
-    expect(releaseCheck).toContain('["sql-catalogues:check"]');
+    expect(releaseCheck).toContain('["sql-catalogues:check:typescript"]');
+    expect(scripts["sql-catalogues:check:typescript"]).toContain("--typescript-only");
     expect(releaseCheck).toContain('["dashboard-spec:check"]');
     expect(releaseCheck).toContain('["build:runtime:check-dashboard-bundle"]');
     expect(releaseCheck).toContain('["npm:lint"]');


### PR DESCRIPTION
## Summary

- add a TypeScript-only generated SQL catalogue check for npm publication
- keep full Go and Python catalogue parity in main CI
- remove the hidden uv dependency found by release dry run 33461944675

## Verification

- pnpm sql-catalogues:check:typescript
- pnpm npm:release-check
- 70 focused contract tests
- pre-commit full generated catalogue check and 1,010 unit tests
