### PR TITLE
WH-514 Isolate npm unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "npm:lint": "oxlint --deny-warnings --import-plugin --vitest-plugin typescript dashboard scripts vitest*.config.ts && pnpm lint:dead-code",
     "npm:release-check": "tsx scripts/check-npm-release.ts",
     "npm:test:packed": "tsx scripts/with-env.ts tsx typescript/core/test/packed-packages.ts",
-    "npm:test:unit": "tsx scripts/with-env.ts node node_modules/vitest/vitest.mjs run --config vitest.unit.config.ts",
+    "npm:test:unit": "tsx scripts/with-env.ts node node_modules/vitest/vitest.mjs run --config vitest.npm.config.ts",
     "npm:typecheck": "tsc -b tsconfig.typecheck.json",
     "format": "oxfmt --write . && pnpm python:format && pnpm go:fmt",
     "format:check": "oxfmt --check . && pnpm python:format:check && pnpm go:fmt:check",

--- a/typescript/core/test/support-matrix.test.ts
+++ b/typescript/core/test/support-matrix.test.ts
@@ -289,6 +289,7 @@ describe("continuous integration", () => {
   it("publishes exact npm tarballs through a focused gate with provenance", async () => {
     const workflow = await read(".github/workflows/release.yml");
     const releaseCheck = await read("scripts/check-npm-release.ts");
+    const npmTestConfig = await read("vitest.npm.config.ts");
     const scripts = (await readManifest("package.json")).scripts as Record<string, string>;
 
     expect(workflow).toContain('tags: ["v*"]');
@@ -307,6 +308,8 @@ describe("continuous integration", () => {
     expect(releaseCheck).toContain('["npm:lint"]');
     expect(releaseCheck).toContain('["npm:typecheck"]');
     expect(releaseCheck).toContain('["npm:test:unit"]');
+    expect(scripts["npm:test:unit"]).toContain("vitest.npm.config.ts");
+    expect(npmTestConfig).toContain('"scripts/sql-catalogue-python-bindings.test.ts"');
     expect(releaseCheck).toContain("WORKHORSE_NPM_TARBALLS: stagedTarballs");
     expect(releaseCheck).toContain('"pack",');
     const packedTest = await read("typescript/core/test/packed-packages.ts");

--- a/vitest.npm.config.ts
+++ b/vitest.npm.config.ts
@@ -1,0 +1,16 @@
+import { configDefaults, defineConfig, mergeConfig } from "vitest/config";
+import baseConfig, { databaseTestFiles } from "./vitest.config.js";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      exclude: [
+        ...configDefaults.exclude,
+        "**/dist/**",
+        ...databaseTestFiles,
+        "scripts/sql-catalogue-python-bindings.test.ts",
+      ],
+    },
+  }),
+);


### PR DESCRIPTION
## Summary

- add an npm-specific Vitest config
- preserve the normal unit and database exclusions
- exclude only the Python AST helper test that requires uv
- keep that helper covered by normal main CI

## Verification

- pnpm npm:test:unit: 102 files, 1,005 tests
- pnpm npm:release-check: exact nine-tarball audit and packed integration passed
- pre-commit general unit suite: 103 files, 1,010 tests
