### PR TITLE
[WH-529] Hold the worker at each empty poll in the poll-cadence fixture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,7 +70,12 @@ priority order, positional outcomes, retries, terminal failures, and independent
 Its suspension fixture pins durable-timer suspension, immediate worker-slot release, replay within
 one logical attempt, and reuse of completed checkpoints. Its ownership fixtures pin cooperative
 cancellation, database-authoritative deadline and execution-timeout settlement, lease-loss fencing,
-non-overlapping worker heartbeat batches, and graceful drain without further claims. The TypeScript suite
+non-overlapping worker heartbeat batches, and graceful drain without further claims. Its poll-cadence
+fixture pins the empty-claim backoff step. `emptyPollsBeforeEnqueue` names the step under test, and
+each language holds its worker at the end of every empty claim so the enqueue lands on that step
+rather than on whichever step the runner reached. `enqueueStallMs` then delays the enqueue past one
+whole step, so an executor that only counts empty polls fails on every run instead of once under
+load. The TypeScript suite
 runs every fixture through `Worker`; Python and Go runtimes must run the same fixtures.
 
 `protocol/v1/requests.json` maps public enqueue inputs to exact PostgreSQL JSON. TypeScript

--- a/go/runtime_conformance_test.go
+++ b/go/runtime_conformance_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -23,10 +23,13 @@ import (
 
 type pollCadenceQueryContextKey struct{}
 
+// pollCadenceQueryTracer holds the worker at the end of each empty claim until the test
+// releases it. Counting empty polls is not enough: an uncounted poll between the count and
+// the enqueue advances the backoff step, and the delay is then measured against the wrong one.
 type pollCadenceQueryTracer struct {
-	initialDelay time.Duration
-	delayOnce    sync.Once
-	emptyPolls   chan struct{}
+	holding  atomic.Bool
+	reached  chan struct{}
+	released chan struct{}
 }
 
 func (tracer *pollCadenceQueryTracer) TraceQueryStart(
@@ -37,7 +40,6 @@ func (tracer *pollCadenceQueryTracer) TraceQueryStart(
 	if !strings.Contains(data.SQL, "claim_many_v1") {
 		return ctx
 	}
-	tracer.delayOnce.Do(func() { time.Sleep(tracer.initialDelay) })
 	return context.WithValue(ctx, pollCadenceQueryContextKey{}, true)
 }
 
@@ -46,9 +48,11 @@ func (tracer *pollCadenceQueryTracer) TraceQueryEnd(
 	_ *pgx.Conn,
 	_ pgx.TraceQueryEndData,
 ) {
-	if ctx.Value(pollCadenceQueryContextKey{}) == true {
-		tracer.emptyPolls <- struct{}{}
+	if ctx.Value(pollCadenceQueryContextKey{}) != true || !tracer.holding.Load() {
+		return
 	}
+	tracer.reached <- struct{}{}
+	<-tracer.released
 }
 
 func TestGoWorkerSatisfiesEverySharedRuntimeFixture(t *testing.T) {
@@ -172,14 +176,17 @@ func executeWorkerPollCadenceFixture(t *testing.T, fixture workerRuntimeFixture)
 	databaseURL := createConformanceDatabase(t, testDatabaseURL(t), "worker-poll-cadence-fixture")
 	ctx := context.Background()
 	tracer := &pollCadenceQueryTracer{
-		initialDelay: 100 * time.Millisecond,
-		emptyPolls:   make(chan struct{}, 4),
+		reached:  make(chan struct{}),
+		released: make(chan struct{}),
 	}
+	tracer.holding.Store(true)
 	config, err := pgxpool.ParseConfig(databaseURL)
 	if err != nil {
 		t.Fatal(err)
 	}
 	config.ConnConfig.Tracer = tracer
+	// The enqueue runs while a held poll still owns its connection.
+	config.MaxConns = 8
 	pool, err := pgxpool.NewWithConfig(ctx, config)
 	if err != nil {
 		t.Fatal(err)
@@ -204,18 +211,30 @@ func executeWorkerPollCadenceFixture(t *testing.T, fixture workerRuntimeFixture)
 	runContext, stop := context.WithCancel(ctx)
 	runResult := make(chan error, 1)
 	go func() { runResult <- worker.Run(runContext) }()
-	for range 2 {
+	// The worker is held at the end of every empty poll, so the enqueue happens against a
+	// known backoff step and no further poll can advance it. The job is committed before the
+	// last poll is released, and the delay is measured from that commit.
+	pollTimeout := time.Duration(fixture.ExpectedMaximumDelayMS+1000) * time.Millisecond
+	var enqueuedAt time.Time
+	for poll := 1; poll <= fixture.EmptyPollsBeforeEnqueue; poll++ {
 		select {
-		case <-tracer.emptyPolls:
-		case <-time.After(time.Duration(fixture.ExpectedMaximumDelayMS+1000) * time.Millisecond):
+		case <-tracer.reached:
+		case <-time.After(pollTimeout):
 			stop()
-			t.Fatal("worker did not complete the empty polls before the backoff check")
+			t.Fatalf("worker did not complete empty poll %d before the backoff check", poll)
 		}
-	}
-	enqueuedAt := time.Now()
-	if _, err := queue.Enqueue(ctx, fixture.JobType, map[string]any{}); err != nil {
-		stop()
-		t.Fatal(err)
+		if poll == fixture.EmptyPollsBeforeEnqueue {
+			// A stall longer than one backoff step. A held worker cannot advance past the
+			// pinned step, so this changes nothing; an unheld one fails on every run.
+			time.Sleep(time.Duration(fixture.EnqueueStallMS) * time.Millisecond)
+			if _, err := queue.Enqueue(ctx, fixture.JobType, map[string]any{}); err != nil {
+				stop()
+				t.Fatal(err)
+			}
+			enqueuedAt = time.Now()
+			tracer.holding.Store(false)
+		}
+		tracer.released <- struct{}{}
 	}
 	select {
 	case handledAt := <-handled:

--- a/go/worker_test.go
+++ b/go/worker_test.go
@@ -45,7 +45,8 @@ type workerRuntimeFixture struct {
 	ExpectedMinimumCallsBeforeSettlement int                              `json:"expectedMinimumCallsBeforeSettlement"`
 	ExpectedMaximumOverlap               int                              `json:"expectedMaximumOverlap"`
 	PollMS                               int                              `json:"pollMs"`
-	IdleMS                               int                              `json:"idleMs"`
+	EmptyPollsBeforeEnqueue              int                              `json:"emptyPollsBeforeEnqueue"`
+	EnqueueStallMS                       int                              `json:"enqueueStallMs"`
 	ExpectedMinimumDelayMS               int                              `json:"expectedMinimumDelayMs"`
 	ExpectedMaximumDelayMS               int                              `json:"expectedMaximumDelayMs"`
 	Mode                                 string                           `json:"mode"`

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -24,6 +24,8 @@ fixtures pin batch ordering and settlement as well as durable-wait suspension, s
 single-logical-attempt replay, and checkpoint reuse when a handler restarts. They also pin
 cooperative cancellation, deadline and execution-timeout settlement against the database clock,
 lease-loss fencing, serialized worker-level heartbeat batches, and graceful drain without further claims.
+Its poll-cadence fixture pins the empty-claim backoff step, and every language holds its worker at
+the end of each empty claim so the step in force at the enqueue is the fixture's, not the runner's.
 
 `v1/requests.json` maps public enqueue inputs to the exact JSON request sent to PostgreSQL. The
 TypeScript suite executes these mappings through `Queue`, so serialization changes fail alongside

--- a/protocol/v1/runtime.json
+++ b/protocol/v1/runtime.json
@@ -170,7 +170,8 @@
     "covers": ["empty-claim-backoff"],
     "jobType": "protocol.poll-cadence",
     "pollMs": 100,
-    "idleMs": 150,
+    "emptyPollsBeforeEnqueue": 2,
+    "enqueueStallMs": 250,
     "expectedMinimumDelayMs": 100,
     "expectedMaximumDelayMs": 300
   },

--- a/python/tests/test_worker_runtime_conformance.py
+++ b/python/tests/test_worker_runtime_conformance.py
@@ -4,6 +4,7 @@ import json
 from collections.abc import Callable, Mapping
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from queue import Empty, SimpleQueue
 from threading import Event, Lock, Thread
 from time import monotonic, sleep
 from typing import Any
@@ -35,14 +36,14 @@ def test_python_worker_satisfies_every_shared_runtime_fixture(database_url: str)
 
     with psycopg.connect(database_url, autocommit=True) as connection:
         for fixture in fixtures:
-            execute_runtime_fixture(connection, fixture)
+            execute_runtime_fixture(connection, fixture, database_url)
             coverage.update(fixture["covers"])
 
     assert coverage == set(manifest["runtimeCoverage"])
 
 
 def execute_runtime_fixture(
-    connection: psycopg.Connection[Any], fixture: Mapping[str, Any]
+    connection: psycopg.Connection[Any], fixture: Mapping[str, Any], database_url: str
 ) -> None:
     executors: dict[str, Callable[[psycopg.Connection[Any], Mapping[str, Any]], None]] = {
         "batch": execute_batch_fixture,
@@ -51,7 +52,10 @@ def execute_runtime_fixture(
         "expiration": execute_expiration_fixture,
         "lease-loss": execute_lease_loss_fixture,
         "heartbeat-cadence": execute_heartbeat_fixture,
-        "poll-cadence": execute_poll_cadence_fixture,
+        # The held poll owns the worker's connection, so the enqueue needs its own.
+        "poll-cadence": lambda enqueue_connection, poll_fixture: execute_poll_cadence_fixture(
+            enqueue_connection, poll_fixture, database_url
+        ),
         "graceful-drain": execute_graceful_drain_fixture,
         "trace-propagation": execute_trace_propagation_fixture,
     }
@@ -464,40 +468,112 @@ def execute_heartbeat_fixture(
     assert heartbeat_calls == calls_at_settlement
 
 
+class HeldPollConnection:
+    """Holds the worker at the end of each empty claim until the test releases it.
+
+    Counting empty polls is not enough: an uncounted poll between the count and the enqueue
+    advances the backoff step, and the delay is then measured against the wrong one.
+    """
+
+    def __init__(self, connection: psycopg.Connection[Any]) -> None:
+        self._connection = connection
+        self.holding = True
+        self.reached: SimpleQueue[None] = SimpleQueue()
+        self.released: SimpleQueue[None] = SimpleQueue()
+
+    @property
+    def autocommit(self) -> bool:
+        return self._connection.autocommit
+
+    def cursor(self) -> Any:
+        return HeldPollCursor(self, self._connection.cursor())
+
+    def release(self) -> None:
+        self.released.put(None)
+
+
+class HeldPollCursor:
+    def __init__(self, gate: HeldPollConnection, cursor: Any) -> None:
+        self._gate = gate
+        self._cursor = cursor
+        self._holds = False
+
+    def __enter__(self) -> HeldPollCursor:
+        self._cursor.__enter__()
+        return self
+
+    def __exit__(self, *args: object) -> object:
+        return self._cursor.__exit__(*args)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._cursor, name)
+
+    def execute(self, sql: str, parameters: Any = ()) -> object:
+        self._holds = self._gate.holding and "claim_many_v1" in sql
+        return self._cursor.execute(sql, parameters)
+
+    def fetchall(self) -> Any:
+        rows = self._cursor.fetchall()
+        if self._holds:
+            self._holds = False
+            self._gate.reached.put(None)
+            self._gate.released.get(timeout=5)
+        return rows
+
+
 def execute_poll_cadence_fixture(
-    connection: psycopg.Connection[Any], fixture: Mapping[str, Any]
+    connection: psycopg.Connection[Any], fixture: Mapping[str, Any], database_url: str
 ) -> None:
     queue_name = runtime_queue(fixture)
     handled = Event()
     handled_at = 0.0
-    worker = Worker(
-        connection,
-        queue=queue_name,
-        worker_id=f"python-{fixture['id']}",
-        poll_ms=fixture["pollMs"],
-        registry_interval_ms=0,
-    )
+    with psycopg.connect(database_url, autocommit=True) as worker_connection:
+        gate = HeldPollConnection(worker_connection)
+        worker = Worker(
+            gate,
+            queue=queue_name,
+            worker_id=f"python-{fixture['id']}",
+            poll_ms=fixture["pollMs"],
+            registry_interval_ms=0,
+        )
 
-    def handle(_payload: object, _context: HandlerContext) -> None:
-        nonlocal handled_at
-        handled_at = monotonic()
-        handled.set()
+        def handle(_payload: object, _context: HandlerContext) -> None:
+            nonlocal handled_at
+            handled_at = monotonic()
+            handled.set()
 
-    worker.handle(fixture["jobType"], handle)
-    running = Thread(target=worker.run)
-    running.start()
-    try:
-        sleep(fixture["idleMs"] / 1_000)
-        Queue(connection).enqueue(fixture["jobType"], {}, EnqueueOptions(queue=queue_name))
-        enqueued_at = monotonic()
-        assert handled.wait(fixture["expectedMaximumDelayMs"] / 1_000 + 1)
-        delay_ms = (handled_at - enqueued_at) * 1_000
-        assert delay_ms >= fixture["expectedMinimumDelayMs"]
-        assert delay_ms <= fixture["expectedMaximumDelayMs"]
-    finally:
-        worker.stop()
-        running.join(timeout=2)
-        assert not running.is_alive()
+        worker.handle(fixture["jobType"], handle)
+        running = Thread(target=worker.run)
+        running.start()
+        try:
+            enqueued_at = 0.0
+            for poll in range(1, fixture["emptyPollsBeforeEnqueue"] + 1):
+                try:
+                    gate.reached.get(timeout=fixture["expectedMaximumDelayMs"] / 1_000 + 1)
+                except Empty:
+                    raise AssertionError(
+                        f"worker did not complete empty poll {poll} before the backoff check"
+                    ) from None
+                if poll == fixture["emptyPollsBeforeEnqueue"]:
+                    # A stall longer than one backoff step. A held worker cannot advance past
+                    # the pinned step, so this changes nothing; an unheld one fails every run.
+                    sleep(fixture["enqueueStallMs"] / 1_000)
+                    Queue(connection).enqueue(
+                        fixture["jobType"], {}, EnqueueOptions(queue=queue_name)
+                    )
+                    enqueued_at = monotonic()
+                    gate.holding = False
+                gate.release()
+            assert handled.wait(fixture["expectedMaximumDelayMs"] / 1_000 + 1)
+            delay_ms = (handled_at - enqueued_at) * 1_000
+            assert delay_ms >= fixture["expectedMinimumDelayMs"]
+            assert delay_ms <= fixture["expectedMaximumDelayMs"]
+        finally:
+            gate.holding = False
+            gate.release()
+            worker.stop()
+            running.join(timeout=2)
+            assert not running.is_alive()
 
 
 def execute_graceful_drain_fixture(

--- a/scripts/verify-sql-protocol.ts
+++ b/scripts/verify-sql-protocol.ts
@@ -163,7 +163,8 @@ export interface HeartbeatCadenceRuntimeFixture extends RuntimeFixtureBase {
 export interface PollCadenceRuntimeFixture extends RuntimeFixtureBase {
   kind: "poll-cadence";
   pollMs: number;
-  idleMs: number;
+  emptyPollsBeforeEnqueue: number;
+  enqueueStallMs: number;
   expectedMinimumDelayMs: number;
   expectedMaximumDelayMs: number;
 }

--- a/typescript/core/test/sql-protocol-conformance.test.ts
+++ b/typescript/core/test/sql-protocol-conformance.test.ts
@@ -520,8 +520,21 @@ async function executePollCadenceRuntimeFixture(
   fixture: PollCadenceRuntimeFixture,
 ): Promise<void> {
   const queueName = `runtime-${fixture.id}`;
+  // The worker is held at the end of every empty claim until the test releases it. Counting
+  // empty polls is not enough: an uncounted poll between the count and the enqueue advances
+  // the backoff step, and the delay is then measured against the wrong one.
+  let holding = true;
+  let pollReached = deferred<void>();
+  let pollReleased = deferred<void>();
   const pollingDatabase = {
-    query: database.query.bind(database),
+    async query(text: string, values?: readonly unknown[]) {
+      const result = await database.query(text, values);
+      if (holding && text.includes("claim_many_v1")) {
+        pollReached.resolve();
+        await pollReleased.promise;
+      }
+      return result;
+    },
   } as Queryable;
   const queue = new Queue(pollingDatabase);
   const handled = deferred<number>();
@@ -536,13 +549,28 @@ async function executePollCadenceRuntimeFixture(
   });
   const running = worker.run();
   try {
-    await sleep(fixture.idleMs);
-    const enqueuedAt = performance.now();
-    await queue.enqueue(fixture.jobType, {}, { queue: queueName });
+    let enqueuedAt = 0;
+    for (let poll = 1; poll <= fixture.emptyPollsBeforeEnqueue; poll += 1) {
+      await pollReached.promise;
+      const release = pollReleased;
+      if (poll === fixture.emptyPollsBeforeEnqueue) {
+        // A stall longer than one backoff step. A held worker cannot advance past the
+        // pinned step, so this changes nothing; an unheld one fails on every run.
+        await sleep(fixture.enqueueStallMs);
+        await queue.enqueue(fixture.jobType, {}, { queue: queueName });
+        enqueuedAt = performance.now();
+        holding = false;
+      }
+      pollReached = deferred<void>();
+      pollReleased = deferred<void>();
+      release.resolve();
+    }
     const delayMs = (await handled.promise) - enqueuedAt;
     expect(delayMs).toBeGreaterThanOrEqual(fixture.expectedMinimumDelayMs);
     expect(delayMs).toBeLessThanOrEqual(fixture.expectedMaximumDelayMs);
   } finally {
+    holding = false;
+    pollReleased.resolve();
     worker.stop();
     await running;
   }


### PR DESCRIPTION
The Go poll-cadence conformance fixture measured its backoff window from a point the test did not control, so a stalled enqueue was scored against the wrong backoff step. Observed on CI run 33580454845 (PR #36, WH-513); the rerun passed. The product is correct, the measurement was not.

## Cause

`executeWorkerPollCadenceFixture` received two signals from a buffered `emptyPolls` channel and then enqueued. The worker never blocked on that channel, so it could complete a third empty poll while the test goroutine was between its second receive and its enqueue commit. The delay was then scored against the two-empty-poll window while the three-empty-poll step was in force. `-race` widens the window that makes this reachable.

Counting empty polls is not enough. The executor now **holds** the worker at the end of every empty claim and releases it only after the job is committed, so the worker cannot advance a step between the observation and the enqueue: it is parked inside the claim query that would have advanced it.

## The other two SDKs shared the fault

TypeScript and Python both slept `idleMs` and enqueued without observing a poll at all, so the step in force was whatever fit in 150 ms of wall clock. Both now hold their worker the same way.

## The fixture states the step instead of implying it

`idleMs: 150` is replaced by:

- `emptyPollsBeforeEnqueue: 2` — names the backoff step under test.
- `enqueueStallMs: 250` — delays the enqueue past one whole step while the worker is held. A held worker cannot advance, so the stall changes nothing; an unheld one fails on every run. The reproduction is permanent rather than a throwaway.

The bounds are unchanged, and deliberately not widened. All three SDKs compute `pollMs * 2 ** max(0, n - 1)` with 0.9-1.1 jitter and a 5 s cap, so step two is 180-220 ms and stays inside the existing 100-300 ms window.

Go pins `MaxConns = 8` because the held poll owns its connection while the enqueue runs. Python gives the worker its own connection for the same reason: a psycopg connection serializes, so a held claim would otherwise block the enqueue meant to release it. Go and TypeScript now take `enqueuedAt` after the insert commits, matching Python.

## Evidence

Releasing the last poll before the enqueue — the previous behavior — fails deterministically in all three:

```
Go         3/3   poll delay 334.956659ms / 308.7068ms / 368.08691ms fell outside fixture bounds
TypeScript 1/1   AssertionError: expected 335.64778300000035 to be less than or equal to 300
Python     3/3   assert 388.1900910055265 <= 300
```

Holding it passes:

```
go test -race -run '.../empty-polls' -count=5    ok, 5/5
vitest sql-protocol-conformance.test.ts          10 passed
pytest test_worker_runtime_conformance.py        passed, 3 consecutive runs
```

`pnpm typecheck` and `pnpm lint` pass, including mypy, ruff, staticcheck and go vet.

`docs/architecture.md` and `protocol/README.md` name the poll-cadence fixture's contract and both new fields. The product is unchanged; `architecture.md` already documented the backoff law.

Closes WH-529.

https://claude.ai/code/session_01Ng3CpDEyGyEnMKcGcqCMBg