### PR TITLE
[WH-535] Hold the install commands in a support.json catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Install the TypeScript package and its schema:
 
 ```bash
 npm install @stablemates/workhorse
-npx workhorse schema install
+npx --package @stablemates/workhorse workhorse schema install
 ```
 
 Install the schema during deployment. Runtime processes should verify compatibility instead of

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -546,10 +546,27 @@ example through an external module. Its consumer test writes a separate module w
 `RunOnce`. The queue integration tests also enqueue through `*pgxpool.Pool` and `*sql.Tx` with the
 pgx stdlib driver.
 
-`scripts/readme-alignment.test.ts` derives SDK support sentences from `support.json`, the Go pgx
-claim from `go/go.mod`, and optional install pins from each SDK changelog's newest entry. It requires
-the TypeScript, Python, and Go README code blocks to be verbatim excerpts of their release-tested
-quickstart files. `pnpm check` runs this focused test before the repository test suite.
+`scripts/readme-alignment.test.ts` derives SDK support sentences from `support.json` and the Go pgx
+claim from `go/go.mod`. It requires the TypeScript, Python, and Go README code blocks to be verbatim
+excerpts of their release-tested quickstart files. `pnpm check` runs this focused test before the
+repository test suite.
+
+`support.json` also owns the install commands under its `install` key: `node` is
+`npm install @stablemates/workhorse`, `python` is `pip install stablemates-workhorse`, `go` is
+`go get github.com/stablemates/workhorse/go`, and `schema` is
+`npx --package @stablemates/workhorse workhorse schema install`. None carries a version.
+`scripts/install-commands.test.ts` requires each command verbatim on the surfaces that introduce the
+product: `README.md` and `typescript/core/README.md` state `node` and `schema`; the
+`dashboard`, `dashboard-server`, `drizzle`, `kysely`, `otel`, `prisma`, and `typeorm` READMEs under
+`typescript/` state `node`; `python/README.md` states `python`; `go/README.md` and
+`go/examples/README.md` state `go`; `site/content/docs/installation.mdx` and `quickstart.mdx` state
+all four; `site/content/docs/for-ai-agents.mdx` states the three language commands; and
+`site/content/docs/api.mdx` states `schema`. `typescript/dashboard-contract/README.md` is exempt
+because it installs a type-only development dependency, and the test fails when a published package
+gains a README that is neither governed nor exempt. Two sweeps cover every tracked Markdown and MDX
+file outside `docs/decisions/`: no install command may name a version, and no file may run the
+`workhorse` binary through `npx` without `--package`, a form `npx` resolves to an unrelated package
+outside a project that already depends on `@stablemates/workhorse`.
 
 Go `ProtocolVersion` is 1. `CheckCompatibility` compares an installed schema version with a client
 protocol version and returns `*CompatibilityError`. Its `Code` is `schema-not-installed`,

--- a/go/examples/README.md
+++ b/go/examples/README.md
@@ -1,6 +1,6 @@
 # Go examples
 
-Install the public beta with `go get github.com/stablemates/workhorse/go@v0.1.0-beta.1`, then set
+Install the public beta with `go get github.com/stablemates/workhorse/go`, then set
 `WORKHORSE_DATABASE_URL` to a database where the Workhorse schema is installed.
 
 - `transaction` enqueues a retryable job inside an application-owned pgx transaction.

--- a/scripts/install-commands.test.ts
+++ b/scripts/install-commands.test.ts
@@ -1,0 +1,160 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { publishedPackages, repositoryRoot } from "./packages.js";
+
+// A reader copies the first install command they see. Nine surfaces printing nine variants is how
+// one of them keeps recommending a version nobody publishes any more, so support.json states each
+// command once and this file is what makes a surface disagreeing with it a failure.
+//
+// Four of the governed surfaces are README files rendered by npm, PyPI, and pkg.go.dev. They are
+// plain Markdown with no build step, so no component and no site generator can reach them; a text
+// assertion can.
+
+const execFileAsync = promisify(execFile);
+
+type InstallCommand = "go" | "node" | "python" | "schema";
+
+interface InstallManifest {
+  readonly install: Readonly<Record<InstallCommand, string>>;
+}
+
+interface GovernedSurface {
+  /** Path from the repository root. */
+  readonly file: string;
+  /** Commands a reader must be able to copy from this surface. */
+  readonly commands: readonly InstallCommand[];
+}
+
+/**
+ * Surfaces that tell a reader what to type.
+ *
+ * A surface is here because it introduces the product to someone who has not installed it. Pages
+ * that mention a package in passing are covered by the no-version and bare-`npx` sweeps below
+ * without having to carry a canonical command of their own.
+ */
+const governedSurfaces: readonly GovernedSurface[] = [
+  { file: "README.md", commands: ["node", "schema"] },
+  { file: "typescript/core/README.md", commands: ["node", "schema"] },
+  { file: "typescript/dashboard/README.md", commands: ["node"] },
+  { file: "typescript/dashboard-server/README.md", commands: ["node"] },
+  { file: "typescript/drizzle/README.md", commands: ["node"] },
+  { file: "typescript/kysely/README.md", commands: ["node"] },
+  { file: "typescript/otel/README.md", commands: ["node"] },
+  { file: "typescript/prisma/README.md", commands: ["node"] },
+  { file: "typescript/typeorm/README.md", commands: ["node"] },
+  { file: "python/README.md", commands: ["python"] },
+  { file: "go/README.md", commands: ["go"] },
+  { file: "go/examples/README.md", commands: ["go"] },
+  { file: "site/content/docs/installation.mdx", commands: ["go", "node", "python", "schema"] },
+  { file: "site/content/docs/quickstart.mdx", commands: ["go", "node", "python", "schema"] },
+  { file: "site/content/docs/for-ai-agents.mdx", commands: ["go", "node", "python"] },
+  { file: "site/content/docs/api.mdx", commands: ["schema"] },
+];
+
+/** Published packages whose README states no runtime install command, and why. */
+const exemptPackageReadmes = new Map([
+  [
+    "typescript/dashboard-contract/README.md",
+    "type-only package installed as a development dependency, never alongside the runtime",
+  ],
+]);
+
+/**
+ * An accepted record states what was decided on its date. ADR 0046 quotes a pinned command that
+ * this policy supersedes, and rewriting it would make the record lie about the decision.
+ */
+const exemptDirectory = "docs/decisions/";
+
+/** Every shape a Workhorse install command uses to name a version. */
+const versionPatterns: readonly { readonly label: string; readonly pattern: RegExp }[] = [
+  { label: "npm version", pattern: /@stablemates\/[\w-]+@\S+/ },
+  { label: "Python version", pattern: /stablemates-workhorse\S*(?:[=<>~!]=|@)\S+/ },
+  { label: "Go version", pattern: /stablemates\/workhorse\/go@\S+/ },
+];
+
+/** Install commands, extracted so a version is reported against the command that carries it. */
+const installCommandPattern =
+  /(?:npm (?:install|i)|pnpm add|yarn add|bun add|pip install|pipx install|uv add|go get|npx --package)[^\n`]*/g;
+
+/** `npx` resolves this to an unrelated package outside a project that already depends on ours. */
+const bareBinaryPattern = /npx workhorse\b/;
+
+async function read(relativePath: string): Promise<string> {
+  return readFile(path.join(repositoryRoot, relativePath), "utf8");
+}
+
+async function readInstallManifest(): Promise<InstallManifest> {
+  return JSON.parse(await read("support.json")) as InstallManifest;
+}
+
+/** Every tracked Markdown and MDX file the policy governs, with its contents. */
+async function documentedSurfaces(): Promise<readonly (readonly [string, string])[]> {
+  const { stdout } = await execFileAsync("git", ["ls-files", "--cached", "-z", "*.md", "*.mdx"], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  const files = stdout
+    .split("\0")
+    .filter(Boolean)
+    .filter((file) => !file.startsWith(exemptDirectory));
+  return Promise.all(files.map(async (file) => [file, await read(file)] as const));
+}
+
+describe("install commands", () => {
+  it("states the same command on every surface that introduces the product", async () => {
+    const manifest = await readInstallManifest();
+    const missing: string[] = [];
+
+    for (const surface of governedSurfaces) {
+      const contents = await read(surface.file);
+      for (const command of surface.commands) {
+        if (!contents.includes(manifest.install[command])) {
+          missing.push(`${surface.file}: ${manifest.install[command]}`);
+        }
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+
+  it("names no version in any documented install command", async () => {
+    const manifest = await readInstallManifest();
+    const pinned: string[] = [];
+
+    for (const [file, contents] of await documentedSurfaces()) {
+      for (const [command] of contents.matchAll(installCommandPattern)) {
+        for (const { label, pattern } of versionPatterns) {
+          if (pattern.test(command)) pinned.push(`${file}: ${label} in ${command.trim()}`);
+        }
+      }
+    }
+    for (const command of Object.values(manifest.install)) {
+      for (const { label, pattern } of versionPatterns) {
+        if (pattern.test(command)) pinned.push(`support.json: ${label} in ${command}`);
+      }
+    }
+
+    expect(pinned).toEqual([]);
+  });
+
+  it("never tells a reader to run the bare `npx workhorse` form", async () => {
+    const bare = (await documentedSurfaces())
+      .filter(([, contents]) => bareBinaryPattern.test(contents))
+      .map(([file]) => file);
+
+    expect(bare).toEqual([]);
+  });
+
+  it("governs the README of every published package", async () => {
+    const governed = new Set(governedSurfaces.map((surface) => surface.file));
+    const ungoverned = (await publishedPackages())
+      .map((entry) => `${entry.location}/README.md`)
+      .filter((file) => !governed.has(file) && !exemptPackageReadmes.has(file));
+
+    expect(ungoverned).toEqual([]);
+  });
+});

--- a/scripts/readme-alignment.test.ts
+++ b/scripts/readme-alignment.test.ts
@@ -13,13 +13,10 @@ interface SupportManifest {
 }
 
 interface ReadmeContract {
-  readonly changelog: string;
   readonly example: string;
   readonly exampleLanguage: string;
-  readonly installPin: RegExp;
   readonly languageSupport: (support: SupportManifest["support"]) => string;
   readonly readme: string;
-  readonly releasePin: (version: string) => string;
 }
 
 async function read(relativePath: string): Promise<string> {
@@ -49,12 +46,6 @@ function versionRange(values: readonly (number | string)[]): string {
     : naturalList(values);
 }
 
-function newestChangelogVersion(contents: string): string {
-  const version = /^## ([^\s]+) — (?:unreleased|\d{4}-\d{2}-\d{2})$/m.exec(contents)?.[1];
-  if (!version) throw new Error("changelog has no release entry");
-  return version;
-}
-
 function fencedExamples(contents: string, language: string): string[] {
   return [
     ...contents.matchAll(
@@ -66,39 +57,26 @@ function fencedExamples(contents: string, language: string): string[] {
 const contracts: readonly ReadmeContract[] = [
   {
     readme: "README.md",
-    changelog: "CHANGELOG.md",
     example: "typescript/examples/quickstart.mjs",
     exampleLanguage: "ts",
-    installPin: /(?:npm install|pnpm add|yarn add|bun add) @stablemates\/workhorse(?:@([^\s]+))?/g,
-    releasePin: (version) => version,
     languageSupport: (support) => `Node.js ${naturalList(support.node.tested)}`,
   },
   {
     readme: "typescript/core/README.md",
-    changelog: "CHANGELOG.md",
     example: "typescript/examples/quickstart.mjs",
     exampleLanguage: "ts",
-    installPin: /(?:npm install|pnpm add|yarn add|bun add) @stablemates\/workhorse(?:@([^\s]+))?/g,
-    releasePin: (version) => version,
     languageSupport: (support) => `Node.js ${naturalList(support.node.tested)}`,
   },
   {
     readme: "python/README.md",
-    changelog: "python/CHANGELOG.md",
     example: "python/examples/quickstart.py",
     exampleLanguage: "python",
-    installPin:
-      /(?:pip install stablemates-workhorse(?:==([^\s]+))?|uv add stablemates-workhorse(?:==([^\s]+))?)/g,
-    releasePin: (version) => version,
     languageSupport: (support) => `Python ${versionRange(support.python.tested)}`,
   },
   {
     readme: "go/README.md",
-    changelog: "go/CHANGELOG.md",
     example: "go/examples/quickstart/main.go",
     exampleLanguage: "go",
-    installPin: /go get github\.com\/stablemates\/workhorse\/go(?:@([^\s]+))?/g,
-    releasePin: (version) => `v${version}`,
     languageSupport: (support) => `Go ${support.go.minimum.replace(/\.0$/, "")} or newer`,
   },
 ];
@@ -119,27 +97,6 @@ describe("SDK README alignment", () => {
     const pgxVersion = /^require github\.com\/jackc\/pgx\/v5 (v[^\s]+)$/m.exec(goMod)?.[1];
     expect(pgxVersion).toBeDefined();
     expect(prose(await read("go/README.md"))).toContain(`The module pins pgx ${pgxVersion}.`);
-  });
-
-  it("keeps any pinned install command on the newest changelog release", async () => {
-    const missingCommands: string[] = [];
-    const stalePins: string[] = [];
-    for (const contract of contracts) {
-      const readme = await read(contract.readme);
-      const newestVersion = contract.releasePin(
-        newestChangelogVersion(await read(contract.changelog)),
-      );
-      const commands = [...readme.matchAll(contract.installPin)];
-      if (commands.length === 0) missingCommands.push(contract.readme);
-      for (const command of commands) {
-        const pin = command.slice(1).find((value) => value !== undefined);
-        if (pin !== undefined && pin !== newestVersion) {
-          stalePins.push(`${contract.readme}: expected ${newestVersion}, found ${pin}`);
-        }
-      }
-    }
-    expect(missingCommands).toEqual([]);
-    expect(stalePins).toEqual([]);
   });
 
   it("uses release-tested files for every SDK example block", async () => {

--- a/site/content/docs/api.mdx
+++ b/site/content/docs/api.mdx
@@ -156,16 +156,24 @@ Exported constants such as `MAX_ENQUEUE_BATCH_SIZE`, `MAX_CHECKPOINT_VALUE_BYTES
 The `workhorse` CLI covers setup and operations without writing code:
 
 ```bash title="Terminal"
-npx workhorse init                              # scaffold config and wiring
-npx workhorse schema install                    # install the schema
-npx workhorse schema status --json              # report schema and PostgreSQL status
-npx workhorse worker --config workhorse.config.js  # run a supervised worker process
-npx workhorse dashboard --port 3000             # serve the operator dashboard
-npx workhorse health --json                     # emit machine-readable queue health
+npx --package @stablemates/workhorse workhorse init
+npx --package @stablemates/workhorse workhorse schema install
+npx --package @stablemates/workhorse workhorse schema status --json
+npx --package @stablemates/workhorse workhorse worker --config workhorse.config.js
+npx --package @stablemates/workhorse workhorse dashboard --port 3000
+npx --package @stablemates/workhorse workhorse health --json
 ```
 
-The package exposes only the `workhorse` binary. Each command rejects unknown options and accepts
-both `--flag value` and `--flag=value`. Run `workhorse <command> --help` for its options.
+- `init` scaffolds config and wiring.
+- `schema install` installs the schema.
+- `schema status --json` reports schema and PostgreSQL status.
+- `worker --config` runs a supervised worker process.
+- `dashboard --port` serves the operator dashboard.
+- `health --json` emits machine-readable queue health.
+
+The package exposes only the `workhorse` binary, named through `--package` for the reason
+[Installation](/docs/installation) gives. Each command rejects unknown options and accepts both
+`--flag value` and `--flag=value`. Run `workhorse <command> --help` for its options.
 
 ## Next
 

--- a/site/content/docs/installation.mdx
+++ b/site/content/docs/installation.mdx
@@ -29,14 +29,14 @@ Install the SDK. Each package includes its default PostgreSQL driver.
   <Tab value="TypeScript">
 
     ```bash
-    npm install @stablemates/workhorse@0.1.0-beta.2
+    npm install @stablemates/workhorse
     ```
 
   </Tab>
   <Tab value="Python">
 
     ```bash
-    pip install stablemates-workhorse==0.1.0b3
+    pip install stablemates-workhorse
     ```
 
     Use the `asyncpg` extra when that is your application's driver instead of Psycopg.
@@ -45,7 +45,7 @@ Install the SDK. Each package includes its default PostgreSQL driver.
   <Tab value="Go">
 
     ```bash
-    go get github.com/stablemates/workhorse/go@v0.1.0-beta.1
+    go get github.com/stablemates/workhorse/go
     ```
 
   </Tab>
@@ -60,7 +60,7 @@ writes a worker configuration, and prints a dashboard mount — but it leaves yo
 manifest alone.
 
 ```bash
-npx workhorse init
+npx --package @stablemates/workhorse workhorse init
 ```
 
 ## Give Workhorse a database
@@ -83,6 +83,10 @@ npx --package @stablemates/workhorse workhorse schema migrate
 npx --package @stablemates/workhorse workhorse schema status
 npx --package @stablemates/workhorse workhorse schema status --json
 ```
+
+`--package` names the package the binary comes from. Without it `npx` looks for a `workhorse`
+package by that bare name, which belongs to someone else, and a Python or Go project has no
+`node_modules` to correct the guess from.
 
 Every command rejects unknown options and accepts both `--flag value` and `--flag=value`.
 Command-specific help exits before the CLI connects to PostgreSQL.

--- a/site/content/docs/quickstart.mdx
+++ b/site/content/docs/quickstart.mdx
@@ -14,21 +14,21 @@ connection string.
   <Tab value="TypeScript">
 
     ```bash
-    npm install @stablemates/workhorse@0.1.0-beta.2
+    npm install @stablemates/workhorse
     ```
 
   </Tab>
   <Tab value="Python">
 
     ```bash
-    pip install stablemates-workhorse==0.1.0b3
+    pip install stablemates-workhorse
     ```
 
   </Tab>
   <Tab value="Go">
 
     ```bash
-    go get github.com/stablemates/workhorse/go@v0.1.0-beta.1
+    go get github.com/stablemates/workhorse/go
     ```
 
   </Tab>
@@ -41,7 +41,7 @@ every lifecycle transition. Install them once through the TypeScript package's d
 regardless of which application SDK you use.
 
 ```bash
-npx --package @stablemates/workhorse@0.1.0-beta.2 workhorse schema install
+npx --package @stablemates/workhorse workhorse schema install
 ```
 
 TypeScript deployment code can call the same installer directly.

--- a/support.json
+++ b/support.json
@@ -1,4 +1,10 @@
 {
+  "install": {
+    "go": "go get github.com/stablemates/workhorse/go",
+    "node": "npm install @stablemates/workhorse",
+    "python": "pip install stablemates-workhorse",
+    "schema": "npx --package @stablemates/workhorse workhorse schema install"
+  },
   "support": {
     "go": {
       "minimum": "1.25.0"

--- a/typescript/core/README.md
+++ b/typescript/core/README.md
@@ -11,7 +11,7 @@ durable execution protocol.
 
 ```bash
 npm install @stablemates/workhorse
-npx workhorse schema install
+npx --package @stablemates/workhorse workhorse schema install
 ```
 
 Install the schema during deployment. Runtime processes should verify compatibility instead of

--- a/typescript/core/test/support-matrix.test.ts
+++ b/typescript/core/test/support-matrix.test.ts
@@ -498,8 +498,6 @@ describe("documentation", () => {
     );
     expect(pythonReadme).not.toContain("Psycopg 3.3 through the next major");
     expect(pythonReadme).not.toContain("asyncpg 0.31 through the next major");
-    expect(pythonReadme).toContain("pip install stablemates-workhorse\n");
-    expect(pythonReadme).not.toContain("stablemates-workhorse==");
     expect(sitePage).toContain(
       "https://github.com/stablemates/workhorse/blob/main/docs/compatibility.md",
     );


### PR DESCRIPTION
Nine install snippets disagreed on pinning and on the schema step, so a reader copying the first one they saw could land on a version nobody publishes any more. `support.json` now states one command per language plus one schema command, all unpinned:

```
npm install @stablemates/workhorse
pip install stablemates-workhorse
go get github.com/stablemates/workhorse/go
npx --package @stablemates/workhorse workhorse schema install
```

`scripts/install-commands.test.ts` requires each command verbatim on the surfaces that introduce the product, and adds two sweeps over every tracked Markdown and MDX file outside `docs/decisions/`: no install command names a version, and none runs the `workhorse` binary through `npx` without `--package`, which `npx` otherwise resolves to an unrelated package.

Four governed surfaces are README files rendered by npm, PyPI, and pkg.go.dev. They have no build step and no component model, so a catalog plus a text assertion is what can reach them. The idiom is the repository's own: `support.json` plus a text-asserting test already keeps the support matrix, the pgx pin, and the release train from drifting.

`typescript/dashboard-contract/README.md` is exempt because it installs a type-only development dependency; the test fails when a published package gains a README that is neither governed nor exempt.

## Superseded rules removed

- `scripts/readme-alignment.test.ts` — the changelog pin test is removed rather than left vacuous, since no pin exists under this policy.
- `typescript/core/test/support-matrix.test.ts` — the Python-only install rule is covered by the sweep.
- `scripts/public-beta-release.test.ts` keeps its hardcoded versions: those gate manifests and changelogs against a release, a different job from what a document tells a reader to type.

`docs/decisions/` stays exempt. ADR 0046 quotes a superseded pin, and an accepted record states what was decided on its date.

## Verification

- Each sweep was mutation-checked: adding a pin to `python/README.md`, restoring a bare `npx` form in `api.mdx`, and altering `go/README.md`'s command each fail exactly one assertion.
- `pnpm test` (full vitest, Python, Go), `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm readme-alignment:check` pass.

https://claude.ai/code/session_0119BNCiqgpomNvqjPX3BSiz