### PR TITLE
[WH-532] Expand Markdown twins and serve them as text/markdown

### DIFF
--- a/deployment/site.conf
+++ b/deployment/site.conf
@@ -1,5 +1,19 @@
 server_tokens off;
 
+# Markdown twins at /docs/<slug>.md are the form an agent reads. nginx maps no
+# extension to Markdown, so without this the origin falls back to
+# application/octet-stream and an agent's tooling treats the page as binary.
+# This block adds to the mapping that nginx.conf's `include mime.types` builds;
+# it does not replace it.
+types {
+  text/markdown md;
+}
+
+# text/markdown is not one of the types nginx labels with a charset by default,
+# and a twin is UTF-8. The list is the nginx default plus Markdown.
+charset utf-8;
+charset_types text/markdown text/xml text/plain text/vnd.wap.wml application/javascript application/rss+xml;
+
 server {
   listen 8080 default_server;
   server_name _;

--- a/site/scripts/gen-docs-index.ts
+++ b/site/scripts/gen-docs-index.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 
 import type { Integration, IntegrationCategory } from "../lib/integrations.js";
 import { siteConfig } from "../lib/site.js";
+import { mdxToMarkdown } from "./mdx-to-markdown.js";
 
 /**
  * Builds everything the docs routes need without loading Fumadocs at runtime.
@@ -286,7 +287,13 @@ const catalogMarkdown = catalog.categories
   .join("\n\n");
 
 const pages = new Map<string, PageRecord>();
-const markdownTwins = new Map<string, string>();
+/**
+ * One Markdown document per page: the `# title` and `> description` lead
+ * followed by the expanded body. The standalone twin adds frontmatter to this
+ * string and `llms-full.txt` embeds it as it stands, so the two stop being
+ * identical while the body they share is built once.
+ */
+const markdownDocuments = new Map<string, string>();
 await Promise.all(
   slugs.map(async (slug) => {
     const source = await readFile(new URL(`${slug}.mdx`, contentDir), "utf8");
@@ -296,6 +303,8 @@ await Promise.all(
       throw new Error(`The docs page "${slug}" is missing a frontmatter description`);
     }
 
+    // The catalog tag becomes Markdown before the tab transform runs, so the
+    // transform never meets a component the sidebar generator owns.
     const body = source
       .replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, "")
       .trimStart()
@@ -303,7 +312,7 @@ await Promise.all(
     if (body.includes("<IntegrationCatalog")) {
       throw new Error(`The Markdown twin for "${slug}" still contains the catalog tag`);
     }
-    markdownTwins.set(slug, `# ${title}\n\n> ${description}\n\n${body}`);
+    markdownDocuments.set(slug, `# ${title}\n\n> ${description}\n\n${mdxToMarkdown(body, slug)}`);
     pages.set(slug, {
       slug,
       url: slug === "index" ? "/docs" : `/docs/${slug}`,
@@ -409,18 +418,32 @@ ${routes
  * Markdown twins, one per page, at `/docs/<slug>.md`.
  *
  * An agent that fetches a docs URL gets an HTML shell it has to strip. These
- * files hand it the source instead. The frontmatter goes, the title becomes an
- * H1, and the body is left alone so identifiers and code survive exactly.
+ * files hand it the source instead. The title becomes an H1, every language tab
+ * is expanded inline, and the code survives exactly.
+ *
+ * The twin restates its title and description as frontmatter and names the HTML
+ * page it stands for, so an agent that keeps the file can still say where it
+ * came from. A client that does not parse YAML loses nothing, because the
+ * `# title` and `> description` lead repeats both. There is no version key: the
+ * runtime compatibility check answers that question.
  */
 await mkdir(new URL("../public/docs/", import.meta.url), { recursive: true });
 await Promise.all(
   [...pages.values()].map(async (page) => {
-    const markdown = markdownTwins.get(page.slug);
-    if (!markdown) throw new Error(`The docs page "${page.slug}" has no Markdown twin`);
+    const document = markdownDocuments.get(page.slug);
+    if (!document) throw new Error(`The docs page "${page.slug}" has no Markdown twin`);
+    const frontmatter = [
+      "---",
+      `title: ${JSON.stringify(page.title)}`,
+      `description: ${JSON.stringify(page.description)}`,
+      `canonical: ${JSON.stringify(`${base}${page.url}`)}`,
+      "---",
+      "",
+    ].join("\n");
     // `index` is served at `/docs`, so its twin is `/docs.md`, not
     // `/docs/index.md`. Every other page keeps its slug.
     const target = page.slug === "index" ? "../public/docs.md" : `../public/docs/${page.slug}.md`;
-    await writeFile(new URL(target, import.meta.url), markdown);
+    await writeFile(new URL(target, import.meta.url), `${frontmatter}\n${document}`);
   }),
 );
 
@@ -457,17 +480,17 @@ ${structure.map((group) => llmsSection(group)).join("\n")}
 );
 
 /**
- * `/llms-full.txt`, every Markdown twin in sidebar order. The separator and
- * canonical URL identify each page, while the page body is the exact string
- * written to its standalone twin.
+ * `/llms-full.txt`, every page in sidebar order. The separator and canonical
+ * URL identify each page, and the document that follows is the same body the
+ * standalone twin carries, without the twin's frontmatter.
  */
 const llmsFullSection = (group: Group, depth = 2): string => {
   const heading = "#".repeat(depth);
   const documents = (group.pages ?? []).map((slug) => {
     const page = pages.get(slug);
-    const markdown = markdownTwins.get(slug);
-    if (!page || !markdown) throw new Error(`The sidebar page "${slug}" has no Markdown twin`);
-    return `---\n\nCanonical source: ${base}${page.url}\n\n${markdown}`;
+    const document = markdownDocuments.get(slug);
+    if (!page || !document) throw new Error(`The sidebar page "${slug}" has no Markdown twin`);
+    return `---\n\nCanonical source: ${base}${page.url}\n\n${document}`;
   });
   const nested = (group.groups ?? []).map((child) => llmsFullSection(child, depth + 1));
   return [`${heading} ${group.title}`, "", ...documents, "", ...nested].join("\n");

--- a/site/scripts/mdx-to-markdown.test.ts
+++ b/site/scripts/mdx-to-markdown.test.ts
@@ -1,0 +1,178 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { mdxToMarkdown } from "./mdx-to-markdown.js";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+describe("the Markdown twin transform", () => {
+  it("expands every tab inline under a bold language label", () => {
+    const markdown = mdxToMarkdown(
+      [
+        "## Install",
+        "",
+        '<Tabs items={["TypeScript", "Python", "Go"]}>',
+        '  <Tab value="TypeScript">',
+        "",
+        "    ```bash",
+        "    npm install @stablemates/workhorse",
+        "    ```",
+        "",
+        "  </Tab>",
+        '  <Tab value="Python">',
+        "    ```bash",
+        "    pip install stablemates-workhorse",
+        "    ```",
+        "  </Tab>",
+        '  <Tab value="Go">',
+        "    ```bash",
+        "    go get github.com/stablemates/workhorse/go",
+        "    ```",
+        "  </Tab>",
+        "</Tabs>",
+        "",
+        "## Next",
+      ].join("\n"),
+      "quickstart",
+    );
+
+    expect(markdown).toBe(
+      [
+        "## Install",
+        "",
+        "**TypeScript**",
+        "",
+        "```bash",
+        "npm install @stablemates/workhorse",
+        "```",
+        "",
+        "**Python**",
+        "",
+        "```bash",
+        "pip install stablemates-workhorse",
+        "```",
+        "",
+        "**Go**",
+        "",
+        "```bash",
+        "go get github.com/stablemates/workhorse/go",
+        "```",
+        "",
+        "## Next",
+      ].join("\n"),
+    );
+  });
+
+  it("adds no heading, so the twin's outline still matches the page", () => {
+    const source = [
+      "# Only heading",
+      "",
+      '<Tabs items={["TypeScript"]}>',
+      '  <Tab value="TypeScript">',
+      "    Prose.",
+      "  </Tab>",
+      "</Tabs>",
+    ].join("\n");
+
+    const headings = mdxToMarkdown(source, "example")
+      .split("\n")
+      .filter((line) => line.startsWith("#"));
+    expect(headings).toEqual(["# Only heading"]);
+  });
+
+  it("de-indents a tab body without touching indentation inside it", () => {
+    const markdown = mdxToMarkdown(
+      [
+        '<Tabs items={["TypeScript"]}>',
+        '  <Tab value="TypeScript">',
+        "    ```ts",
+        "    if (ready) {",
+        "      run();",
+        "    }",
+        "    ```",
+        "  </Tab>",
+        "</Tabs>",
+      ].join("\n"),
+      "example",
+    );
+
+    expect(markdown).toContain("```ts\nif (ready) {\n  run();\n}\n```");
+  });
+
+  it("leaves prose and fenced code outside a tab exactly as it found them", () => {
+    const source = ["Prose with `Array<Job>` in it.", "", "```ts", "  const x = 1;", "```"].join(
+      "\n",
+    );
+    expect(mdxToMarkdown(source, "example")).toBe(source);
+  });
+
+  it("labels each valueless tab from its own place in the items list", () => {
+    const markdown = mdxToMarkdown(
+      [
+        '<Tabs items={["TypeScript", "Python", "Go"]}>',
+        "  <Tab>",
+        "    One.",
+        "  </Tab>",
+        "  <Tab>",
+        "    Two.",
+        "  </Tab>",
+        "  <Tab>",
+        "    Three.",
+        "  </Tab>",
+        "</Tabs>",
+      ].join("\n"),
+      "example",
+    );
+    expect(markdown).toBe(
+      [
+        "**TypeScript**",
+        "",
+        "One.",
+        "",
+        "**Python**",
+        "",
+        "Two.",
+        "",
+        "**Go**",
+        "",
+        "Three.",
+        // A tabs block ends with a blank line, so whatever follows it in the
+        // page starts its own paragraph.
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("throws on an MDX component it does not know, naming the component and the page", () => {
+    expect(() => mdxToMarkdown("<Callout>Read this.</Callout>", "retries")).toThrow(
+      /"retries".*<Callout>/s,
+    );
+  });
+
+  it("throws on a component the page hides inside a tab", () => {
+    const source = [
+      '<Tabs items={["Go"]}>',
+      '  <Tab value="Go">',
+      "    <Steps>one</Steps>",
+      "  </Tab>",
+      "</Tabs>",
+    ].join("\n");
+    expect(() => mdxToMarkdown(source, "workers")).toThrow(/<Steps>/);
+  });
+
+  it("throws when a tabs block is left open", () => {
+    expect(() => mdxToMarkdown('<Tabs items={["Go"]}>', "workers")).toThrow(/unclosed/);
+  });
+});
+
+describe("the origin's Markdown type", () => {
+  it("serves .md as text/markdown with a UTF-8 charset", async () => {
+    const config = await readFile(resolve(repositoryRoot, "deployment/site.conf"), "utf8");
+    expect(config).toMatch(/types\s*\{\s*text\/markdown\s+md;\s*}/);
+    expect(config).toMatch(/^\s*charset\s+utf-8;$/m);
+    expect(config).toMatch(/^\s*charset_types\s+[^;]*\btext\/markdown\b[^;]*;$/m);
+  });
+});

--- a/site/scripts/mdx-to-markdown.ts
+++ b/site/scripts/mdx-to-markdown.ts
@@ -1,0 +1,160 @@
+/**
+ * Turns an MDX page body into the Markdown an agent reads at `/docs/<slug>.md`.
+ *
+ * A docs page shows its three languages in a `<Tabs>` component, so the HTML
+ * hides two of them behind a control an agent cannot click. Copying the body
+ * into the twin unchanged hands the agent the raw `<Tabs>` and `<Tab>` tags
+ * instead, which its tooling reads as markup it has to strip. This transform
+ * expands every tab inline under a bold language label, so the twin carries all
+ * three languages as ordinary Markdown.
+ *
+ * Expansion costs no size. The twin already carried every language; only the
+ * HTML hid two of them.
+ *
+ * A tab body is indented to sit under its tag, so the transform removes that
+ * indentation. A fenced block indented by four spaces is an indented code block
+ * wrapped in a fence, and a reader counting backticks sees the wrong thing.
+ *
+ * The transform knows `Tabs` and `Tab` and nothing else. Any other MDX
+ * component throws, naming the component and the page, because a silent pass
+ * through would put a bare JSX tag in front of an agent.
+ */
+
+/** MDX components this transform can expand. Anything else is a build failure. */
+const knownComponents: ReadonlySet<string> = new Set(["Tabs", "Tab"]);
+
+const fenceEdge = /^\s*(?:```|~~~)/;
+const tabsOpen = /^\s*<Tabs\b([^>]*)>\s*$/;
+const tabsClose = /^\s*<\/Tabs>\s*$/;
+const tabOpen = /^\s*<Tab\b([^>]*)>\s*$/;
+const tabClose = /^\s*<\/Tab>\s*$/;
+const itemsAttribute = /items=\{\[(.*?)]}/;
+const valueAttribute = /value="([^"]*)"/;
+const inlineCode = /`[^`]*`/g;
+const componentTag = /<\/?([A-Z][A-Za-z0-9]*)/g;
+
+interface OpenTab {
+  readonly label: string;
+  readonly lines: string[];
+}
+
+/**
+ * Removes the shared indentation of a tab body and drops its blank edges, so a
+ * fenced block that sat under `<Tab>` starts at the left margin.
+ */
+function dedent(lines: readonly string[]): string[] {
+  const filled = lines.filter((line) => line.trim() !== "");
+  if (filled.length === 0) return [];
+  const indent = Math.min(...filled.map((line) => line.length - line.trimStart().length));
+  const flush = lines.map((line) => (line.trim() === "" ? "" : line.slice(indent)));
+  while (flush.length > 0 && flush[0] === "") flush.shift();
+  while (flush.length > 0 && flush.at(-1) === "") flush.pop();
+  return flush;
+}
+
+/** Reads the labels out of `items={["TypeScript", "Python", "Go"]}`. */
+function tabsItems(attributes: string): string[] {
+  const items = itemsAttribute.exec(attributes);
+  if (!items?.[1]) return [];
+  return [...items[1].matchAll(/"([^"]*)"/g)].map((match) => match[1] ?? "");
+}
+
+function unknownComponent(line: string, page: string): void {
+  for (const match of line.replace(inlineCode, "").matchAll(componentTag)) {
+    const tag = match[1] ?? "";
+    if (knownComponents.has(tag)) continue;
+    throw new Error(
+      `The docs page "${page}" uses the MDX component <${tag}>, which the Markdown twin ` +
+        "transform does not know. Teach site/scripts/mdx-to-markdown.ts how to expand it.",
+    );
+  }
+}
+
+/**
+ * Expands `body`, an MDX page with its frontmatter already removed, into
+ * Markdown. Throws on any MDX component other than `Tabs` and `Tab`, naming the
+ * component and `page`.
+ */
+export function mdxToMarkdown(body: string, page: string): string {
+  const output: string[] = [];
+  let items: string[] = [];
+  let itemIndex = 0;
+  let expanded: string[] | undefined;
+  let tab: OpenTab | undefined;
+  let inFence = false;
+  // A `</Tabs>` line already ends its block with a blank line, so the blank line
+  // that followed the tag in the source would double it.
+  let skipBlankLine = false;
+
+  const sink = (): string[] => tab?.lines ?? output;
+
+  const closeTab = (): void => {
+    if (!tab || !expanded) return;
+    expanded.push(`**${tab.label}**`, "", ...dedent(tab.lines), "");
+    tab = undefined;
+  };
+
+  for (const line of body.split("\n")) {
+    if (skipBlankLine) {
+      skipBlankLine = false;
+      if (line.trim() === "") continue;
+    }
+
+    if (fenceEdge.test(line)) {
+      inFence = !inFence;
+      sink().push(line);
+      continue;
+    }
+    if (inFence) {
+      sink().push(line);
+      continue;
+    }
+
+    const opensTabs = tabsOpen.exec(line);
+    if (opensTabs) {
+      if (expanded) throw new Error(`The docs page "${page}" nests <Tabs> inside <Tabs>`);
+      items = tabsItems(opensTabs[1] ?? "");
+      itemIndex = 0;
+      expanded = [];
+      continue;
+    }
+
+    if (tabsClose.test(line)) {
+      if (!expanded) throw new Error(`The docs page "${page}" closes a <Tabs> it never opened`);
+      closeTab();
+      while (expanded.at(-1) === "") expanded.pop();
+      output.push(...expanded, "");
+      expanded = undefined;
+      skipBlankLine = true;
+      continue;
+    }
+
+    const opensTab = tabOpen.exec(line);
+    if (opensTab) {
+      if (!expanded) throw new Error(`The docs page "${page}" opens a <Tab> outside <Tabs>`);
+      closeTab();
+      const attributes = opensTab[1] ?? "";
+      const label = valueAttribute.exec(attributes)?.[1] ?? items[itemIndex];
+      itemIndex += 1;
+      if (!label) {
+        throw new Error(`The docs page "${page}" has a <Tab> with no value and no items entry`);
+      }
+      tab = { label, lines: [] };
+      continue;
+    }
+
+    if (tabClose.test(line)) {
+      if (!tab) throw new Error(`The docs page "${page}" closes a <Tab> it never opened`);
+      closeTab();
+      continue;
+    }
+
+    unknownComponent(line, page);
+    sink().push(line);
+  }
+
+  if (expanded) throw new Error(`The docs page "${page}" leaves a <Tabs> unclosed`);
+  if (inFence) throw new Error(`The docs page "${page}" leaves a code fence unclosed`);
+
+  return output.join("\n");
+}

--- a/typescript/core/test/site-smoke.ts
+++ b/typescript/core/test/site-smoke.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
 import { setTimeout as sleep } from "node:timers/promises";
 import { resolve } from "node:path";
 import { WORKHORSE_VERSION } from "../src/version.js";
@@ -61,6 +62,9 @@ try {
     ["/docs/integrations", ["Verified", "Documented", "Tested against drizzle-orm"]],
     ["/docs/integrations.md", ["ORMs and query builders", "Tested against drizzle-orm"]],
     ["/docs/quickstart", ["quickstart", "worker"]],
+    // The twin expands every language tab inline, so an agent that fetches it
+    // sees the Python install the HTML hides behind a tab control.
+    ["/docs/quickstart.md", ["**TypeScript**", "**Python**", "**Go**", "pip install"]],
     ["/docs/retries", ["retry", "backoff"]],
     ["/llms.txt", ["llms-full.txt", "/docs/quickstart.md"]],
     ["/llms-full.txt", ["https://workhorse.run/docs/quickstart", "Queue.enqueue"]],
@@ -82,6 +86,44 @@ try {
         throw new Error(`${path} omitted required token ${token}`);
       }
     }
+  }
+
+  // `expectations` proves a page contains something. A twin has to prove the
+  // opposite: that no MDX tag survived the transform. Sweep every page the
+  // generator wrote rather than a sample, because one unexpanded page is one
+  // agent reading markup where it expected code.
+  const docsIndex = JSON.parse(
+    await readFile(resolve(repositoryRoot, "site/.source/docs-index.json"), "utf8"),
+  ) as { pages: Record<string, { url: string }> };
+  const twinPaths = Object.values(docsIndex.pages).map((page) =>
+    // `index` is served at `/docs`, so its twin is `/docs.md`.
+    page.url === "/docs" ? "/docs.md" : `${page.url}.md`,
+  );
+  if (twinPaths.length === 0) throw new Error("The docs index listed no pages to sweep");
+
+  const forbidden = [
+    ...twinPaths.map((path) => [path, ["<Tab"]] as const),
+    ["/llms-full.txt", ["<Tab"]] as const,
+  ] as const;
+
+  for (const [path, tokens] of forbidden) {
+    const response = await fetch(`${baseUrl}${path}`);
+    const body = await response.text();
+    if (!response.ok) throw new Error(`${path} returned ${response.status}`);
+    for (const token of tokens) {
+      if (body.includes(token)) throw new Error(`${path} still carries the MDX tag ${token}`);
+    }
+  }
+
+  // Expanding the tabs cost no size, because the twins already carried all three
+  // languages and de-indenting the fences gave a little back. The bound catches a
+  // generator that starts repeating content, not ordinary growth.
+  const llmsFullBytes = Buffer.byteLength(
+    await (await fetch(`${baseUrl}/llms-full.txt`)).text(),
+    "utf8",
+  );
+  if (llmsFullBytes > 320_000) {
+    throw new Error(`llms-full.txt grew to ${llmsFullBytes} bytes, well past its 256 KB shape`);
   }
 
   const landingHtml = await (await fetch(`${baseUrl}/`)).text();


### PR DESCRIPTION
Execution Issue from [ADR 0049](docs/decisions/0049-publish-one-agent-documentation-layer.md), assembled on WH-525 and decided by WH-526.

## Problem

A docs page shows its three languages in a `<Tabs>` component, and `site/scripts/gen-docs-index.ts` copied the page body into its Markdown twin unchanged. An agent that appended `.md` to a URL got raw `<Tabs>` and `<Tab>` tags, and the origin labelled the response `application/octet-stream`. Three of the four baseline sessions had their tooling flag the twins as binary.

## Change

- `site/scripts/mdx-to-markdown.ts` is a new module rather than more surface on the 300-line generator. It expands every `<Tab>` inline under a bold language label (`**TypeScript**`, `**Python**`, `**Go**`) and de-indents the fenced block. It adds no heading, so a twin's heading outline still matches its page.
- The transform knows `Tabs` and `Tab` and throws on any other MDX component, naming the component and the page, alongside the generator's existing throws for a missing description, an unlisted page, and a page listed twice.
- Twins carry `title`, `description`, and `canonical` frontmatter and no version key; the runtime compatibility check answers that question. The `# title` and `> description` lead stays, so a client that does not parse YAML loses nothing.
- The generator builds one document per page and wraps it two ways, so `llms-full.txt` embeds the same body without the twin's frontmatter.
- `deployment/site.conf` adds `text/markdown` to the type map nginx builds from `mime.types` and names it in `charset_types`.

## Verification

- `site/scripts/mdx-to-markdown.test.ts` covers tab expansion, both tab-body indentation styles, de-indentation, heading parity, the items-list label fallback, and the unknown-component throw.
- `typescript/core/test/site-smoke.ts` gains a negative table — its `expectations` table is contains-only — sweeping all 42 twins plus `llms-full.txt` for `<Tab`, from `.source/docs-index.json` rather than a sample. It also asserts `quickstart.md` carries all three bold labels and `pip install`, and bounds `llms-full.txt`.
- Every new guard was proven to fail before being restored: the twin sweep reported `/docs/agentic-flow.md still carries the MDX tag <Tab`, the `quickstart.md` labels failed, the generator threw `The docs page "retries" uses the MDX component <Callout>`, and the `site.conf` assertion failed with the type block removed.
- `llms-full.txt` went 251.4 KB to 240.1 KB. Expansion costs no size, because the twins already carried all three languages, and de-indenting the fences gave a little back.
- `pnpm format:check`, `oxlint`, `knip`, `pnpm typecheck`, `pnpm test` (1636 passed), and `pnpm test:site-smoke` all pass.

## Known gap

Nothing in the repository runs the site's nginx. `site-smoke.ts` starts `vite preview`, which serves `.md` as `text/markdown` even while production serves `application/octet-stream`. This proves the configuration states the right type, not that nginx honours it; that proof has its own Issue. Out of band, running nginx 1.29 over this config and the generated twins returned `Content-Type: text/markdown; charset=utf-8` for `/docs/quickstart.md` and `text/html; charset=utf-8` for `/`, confirming the type map merges rather than replaces.

https://claude.ai/code/session_015zpuHcpFNZFQYndJRt9chz