### PR TITLE
[WH-538] Correct the Python floor in docs/architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,7 +87,7 @@ every mapping. `manifest.fixtureCoverage` declares the complete identifier set f
 and with the identifiers executed by its runner.
 
 The Python distribution is `stablemates-workhorse`, and its import package is `workhorse`. It requires
-Python 3.10 or newer. The distribution depends on Psycopg 3.3 or newer and below 4. The `asyncpg`
+Python 3.12 or newer. The distribution depends on Psycopg 3.3 or newer and below 4. The `asyncpg`
 extra adds asyncpg 0.31 or newer and below 1. `python/src/workhorse/client.py` exports synchronous `Queue` for Psycopg and
 asynchronous `AsyncQueue.from_psycopg` and `AsyncQueue.from_asyncpg` constructors. Both clients
 expose `enqueue`, `enqueue_with_result`, `enqueue_many`, `enqueue_many_with_results`, and


### PR DESCRIPTION
## What

`docs/architecture.md` claimed the Python distribution requires Python 3.10 or newer. It now states 3.12.

## Why

The reference contradicted the manifest it describes. `support.json` declares `python.minimum` as `3.12`, `python/pyproject.toml` declares `requires-python = ">=3.12"` and classifies 3.12 through 3.14, and `docs/compatibility.md` already stated a 3.12 floor. `docs/architecture.md` is the precise reference, so a wrong floor there is the one place a reader cannot check the claim against.

## The rest of the file

Every other support floor stated in `docs/architecture.md` already agrees with `support.json`:

| Claim | Line | `support.json` |
| --- | --- | --- |
| Go 1.25 or newer | 445 | `go.minimum` `1.25.0` |
| PostgreSQL 15 through 18 | 1540 | `postgres.minimum` 15, `tested` 15–18 |
| PostgreSQL 15+ required | 2758 | `postgres.minimum` 15 |
| Python 3.12 or newer | 90 | `python.minimum` `3.12` |

No Node.js floor is claimed in the file. Line 2366 names the Node 24 Alpine demo image, which is a tested major rather than a floor. The Psycopg and asyncpg ranges on lines 90–91 match `python/pyproject.toml`.

A repository-wide grep for `Python 3.(9|10|11)` across `docs/`, `site/`, and all four language trees returns nothing.

## Verification

Full `pnpm test` scope, green, on this branch rebased onto `564b4499`:

- TypeScript unit: 106 files, 1045 tests passed
- TypeScript database: 32 files, 613 tests passed
- Python: 56 unit, 92 database passed
- Go: `go test ./...` ok on every package

The database tier ran with `--maxWorkers=2`. At default concurrency the shared PostgreSQL instance returns `remaining connection slots are reserved for roles with the SUPERUSER attribute`, because parallel worktree sessions hold 20–35 of its 100 connections. That is local contention, not a property of this branch.

Closes WH-538.

https://claude.ai/code/session_019h3DqKknntAWTLct3vMtsV