### PR TITLE
[WH-536] State the schema install step on every install surface

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -15,8 +15,17 @@ An AI agent should read [the Workhorse documentation index](https://workhorse.ru
 go get github.com/stablemates/workhorse/go
 ```
 
-Install the schema during deployment with the TypeScript CLI. Runtime processes should verify
-compatibility instead of attempting schema changes.
+Install the schema once, as a deployment step. The application never installs or migrates it.
+
+```bash
+npx --package @stablemates/workhorse workhorse schema install
+```
+
+The machine that runs that deployment step needs Node.js 22 or newer. The application itself needs
+no Node.js.
+
+Runtime processes verify compatibility instead of changing the schema. Call `AssertCompatible` at
+startup.
 
 Requires Go 1.25 or newer and PostgreSQL 15 through 18. The module pins pgx v5.9.2.
 

--- a/python/README.md
+++ b/python/README.md
@@ -15,10 +15,18 @@ An AI agent should read [the Workhorse documentation index](https://workhorse.ru
 pip install stablemates-workhorse
 ```
 
-Install the schema during deployment with the TypeScript CLI. Runtime processes should verify
-compatibility instead of attempting schema changes: call `assert_schema_compatible(connection)` at
-startup, or `assert_schema_compatible_psycopg` or `assert_schema_compatible_asyncpg` when the
-application is asynchronous.
+Install the schema once, as a deployment step. The application never installs or migrates it.
+
+```bash
+npx --package @stablemates/workhorse workhorse schema install
+```
+
+The machine that runs that deployment step needs Node.js 22 or newer. The application itself needs
+no Node.js.
+
+Runtime processes verify compatibility instead of changing the schema. Call
+`assert_schema_compatible(connection)` at startup. Call `assert_schema_compatible_psycopg` or
+`assert_schema_compatible_asyncpg` when the application is asynchronous.
 
 Requires Python 3.12 through 3.14 and PostgreSQL 15 through 18.
 

--- a/scripts/install-commands.test.ts
+++ b/scripts/install-commands.test.ts
@@ -45,14 +45,29 @@ const governedSurfaces: readonly GovernedSurface[] = [
   { file: "typescript/otel/README.md", commands: ["node"] },
   { file: "typescript/prisma/README.md", commands: ["node"] },
   { file: "typescript/typeorm/README.md", commands: ["node"] },
-  { file: "python/README.md", commands: ["python"] },
-  { file: "go/README.md", commands: ["go"] },
+  { file: "python/README.md", commands: ["python", "schema"] },
+  { file: "go/README.md", commands: ["go", "schema"] },
   { file: "go/examples/README.md", commands: ["go"] },
   { file: "site/content/docs/installation.mdx", commands: ["go", "node", "python", "schema"] },
   { file: "site/content/docs/quickstart.mdx", commands: ["go", "node", "python", "schema"] },
   { file: "site/content/docs/for-ai-agents.mdx", commands: ["go", "node", "python"] },
   { file: "site/content/docs/api.mdx", commands: ["schema"] },
 ];
+
+/** Markdown wraps prose at will, so a sentence rule compares runs of whitespace as one space. */
+function collapse(contents: string): string {
+  return contents.replace(/\s+/g, " ");
+}
+
+/** The package that owns schema installation. Every other package points at it instead. */
+const coreLocation = "typescript/core";
+
+/**
+ * An add-on runs against a schema it does not own. Naming core, with a link, is what stops a reader
+ * from hunting for a schema step in a package that has none.
+ */
+const schemaOwnerSentence =
+  "[Workhorse core](https://workhorse.run/docs/installation) owns schema installation and changes.";
 
 /** Published packages whose README states no runtime install command, and why. */
 const exemptPackageReadmes = new Map([
@@ -147,6 +162,26 @@ describe("install commands", () => {
       .map(([file]) => file);
 
     expect(bare).toEqual([]);
+  });
+
+  it("points every add-on README at core for schema installation", async () => {
+    const manifest = await readInstallManifest();
+    const wrong: string[] = [];
+
+    for (const { location } of await publishedPackages()) {
+      if (location === coreLocation) continue;
+      const file = `${location}/README.md`;
+      if (exemptPackageReadmes.has(file)) continue;
+      const contents = await read(file);
+      // Compared with runs of whitespace collapsed, so rewrapping a paragraph cannot fail the rule.
+      if (!collapse(contents).includes(schemaOwnerSentence)) {
+        wrong.push(`${file}: does not name core as owner`);
+      }
+      if (contents.includes(manifest.install.schema))
+        wrong.push(`${file}: carries a schema command`);
+    }
+
+    expect(wrong).toEqual([]);
   });
 
   it("governs the README of every published package", async () => {

--- a/site/content/docs/api.mdx
+++ b/site/content/docs/api.mdx
@@ -153,22 +153,20 @@ Exported constants such as `MAX_ENQUEUE_BATCH_SIZE`, `MAX_CHECKPOINT_VALUE_BYTES
 
 ## CLI
 
-The `workhorse` CLI covers setup and operations without writing code:
+The `workhorse` CLI covers setup and operations without writing code. Every subcommand runs through
+the same invocation, shown here with `schema install`:
 
 ```bash title="Terminal"
-npx --package @stablemates/workhorse workhorse init
 npx --package @stablemates/workhorse workhorse schema install
-npx --package @stablemates/workhorse workhorse schema status --json
-npx --package @stablemates/workhorse workhorse worker --config workhorse.config.js
-npx --package @stablemates/workhorse workhorse dashboard --port 3000
-npx --package @stablemates/workhorse workhorse health --json
 ```
+
+Substitute any of these subcommands:
 
 - `init` scaffolds config and wiring.
 - `schema install` installs the schema.
 - `schema status --json` reports schema and PostgreSQL status.
-- `worker --config` runs a supervised worker process.
-- `dashboard --port` serves the operator dashboard.
+- `worker --config workhorse.config.js` runs a supervised worker process.
+- `dashboard --port 3000` serves the operator dashboard.
 - `health --json` emits machine-readable queue health.
 
 The package exposes only the `workhorse` binary, named through `--package` for the reason

--- a/site/content/docs/installation.mdx
+++ b/site/content/docs/installation.mdx
@@ -42,12 +42,18 @@ Install the SDK. Each package includes its default PostgreSQL driver.
 
     Use the `asyncpg` extra when that is your application's driver instead of Psycopg.
 
+    Your application never installs the schema. A deployment step installs it once, and that step
+    runs on Node.js.
+
   </Tab>
   <Tab value="Go">
 
     ```bash
     go get github.com/stablemates/workhorse/go
     ```
+
+    Your application never installs the schema. A deployment step installs it once, and that step
+    runs on Node.js.
 
   </Tab>
 </Tabs>

--- a/site/content/docs/quickstart.mdx
+++ b/site/content/docs/quickstart.mdx
@@ -5,8 +5,8 @@ description: Install the schema, run your first job, then kill the worker mid-jo
 
 In five minutes you will enqueue a job, run it, and then prove the interesting part: a job that
 survives its own worker being killed. Choose TypeScript, Python, or Go for the application code.
-Schema installation uses the Node.js 22+ Workhorse CLI. Every path also needs a PostgreSQL
-connection string.
+Schema installation uses the Workhorse CLI, which runs on Node.js. Every path also needs a
+PostgreSQL connection string.
 
 ## 1. Install
 
@@ -24,12 +24,18 @@ connection string.
     pip install stablemates-workhorse
     ```
 
+    Your application never installs the schema. A deployment step installs it once, and that step
+    runs on Node.js.
+
   </Tab>
   <Tab value="Go">
 
     ```bash
     go get github.com/stablemates/workhorse/go
     ```
+
+    Your application never installs the schema. A deployment step installs it once, and that step
+    runs on Node.js.
 
   </Tab>
 </Tabs>
@@ -43,6 +49,9 @@ regardless of which application SDK you use.
 ```bash
 npx --package @stablemates/workhorse workhorse schema install
 ```
+
+That step runs on Node.js, even when the application is written in Python or Go.
+[Compatibility](/docs/compatibility) names the version.
 
 TypeScript deployment code can call the same installer directly.
 

--- a/typescript/core/test/support-matrix.test.ts
+++ b/typescript/core/test/support-matrix.test.ts
@@ -498,6 +498,12 @@ describe("documentation", () => {
     );
     expect(pythonReadme).not.toContain("Psycopg 3.3 through the next major");
     expect(pythonReadme).not.toContain("asyncpg 0.31 through the next major");
+    // A Python or Go application installs the schema with the Node.js CLI, so its README is the one
+    // place outside Compatibility that states the deployment machine's Node floor. Deriving the
+    // sentence here keeps that number from drifting when support.json raises the floor.
+    const deploymentNodeFloor = `The machine that runs that deployment step needs Node.js ${MINIMUM_NODE_MAJOR} or newer.`;
+    expect(pythonReadme).toContain(deploymentNodeFloor);
+    expect(goReadme).toContain(deploymentNodeFloor);
     expect(sitePage).toContain(
       "https://github.com/stablemates/workhorse/blob/main/docs/compatibility.md",
     );

--- a/typescript/dashboard-server/README.md
+++ b/typescript/dashboard-server/README.md
@@ -40,8 +40,9 @@ Standalone deployments must use `singleAdmin`, bind to loopback or a Unix socket
 and set the exact HTTPS `publicOrigin` when a proxy terminates TLS. Operator authorization remains the
 host application's responsibility.
 
-The server reads core-owned `workhorse.dashboard_*_v1` views and versioned SQL functions. Workers can
-run in other processes because PostgreSQL owns their registry and operator pause state.
+The server reads core-owned `workhorse.dashboard_*_v1` views and versioned SQL functions. [Workhorse core](https://workhorse.run/docs/installation)
+owns schema installation and changes. Workers can run in other processes because PostgreSQL owns
+their registry and operator pause state.
 
 ## Next
 

--- a/typescript/dashboard/README.md
+++ b/typescript/dashboard/README.md
@@ -30,8 +30,9 @@ const response = (await host.handle(request)) ?? new Response("Not found", { sta
 
 This facade packages the React application and preserves the public server, client, wire, presentation,
 and standalone subpaths. The server remains responsible for schema compatibility checks and never
-installs schema or owns the caller's database. The embedding application owns authentication,
-authorization, routing, and the browser-visible origin.
+installs schema or owns the caller's database. [Workhorse core](https://workhorse.run/docs/installation) owns schema
+installation and changes. The embedding application owns authentication, authorization, routing, and
+the browser-visible origin.
 
 Applications rendering the React components directly must include
 `@stablemates/workhorse-dashboard/styles.css` and wrap `Dashboard` in `WorkhorseThemeProvider` so

--- a/typescript/drizzle/README.md
+++ b/typescript/drizzle/README.md
@@ -31,9 +31,10 @@ await db.transaction(async (tx) => {
 
 ## Package boundary
 
-The adapter never closes caller-owned database resources unless `close` is configured. Workhorse core
-owns schema installation and changes. Database errors are rethrown as `DrizzleQueryError`, with the
-original error in `cause` and its PostgreSQL code copied to `code` when available.
+The adapter never closes caller-owned database resources unless `close` is configured.
+[Workhorse core](https://workhorse.run/docs/installation) owns schema installation and changes.
+Database errors are rethrown as `DrizzleQueryError`, with the original error in `cause` and its
+PostgreSQL code copied to `code` when available.
 
 ## Next
 

--- a/typescript/kysely/README.md
+++ b/typescript/kysely/README.md
@@ -32,10 +32,11 @@ await database.transaction().execute(async (transaction) => {
 
 ## Package boundary
 
-The adapter never destroys a caller-owned Kysely database unless `close` is configured. Workhorse core
-owns schema installation and changes. Pass the `pg` pool used by `PostgresDialect` as
-`notificationPool` for `LISTEN/NOTIFY`; otherwise workers poll. Database errors become
-`KyselyQueryError`, with the original error in `cause` and its PostgreSQL code copied to `code`.
+The adapter never destroys a caller-owned Kysely database unless `close` is configured.
+[Workhorse core](https://workhorse.run/docs/installation) owns schema installation and changes.
+Pass the `pg` pool used by `PostgresDialect` as `notificationPool` for `LISTEN/NOTIFY`; otherwise
+workers poll. Database errors become `KyselyQueryError`, with the original error in `cause` and its
+PostgreSQL code copied to `code`.
 
 ## Next
 

--- a/typescript/otel/README.md
+++ b/typescript/otel/README.md
@@ -30,6 +30,11 @@ Workhorse uses the host application's global tracer, meter, logger, context, and
 providers. A second active Workhorse telemetry provider is rejected instead of silently replacing
 the first one.
 
+## Package boundary
+
+The adapter reads telemetry providers and installs no database object. [Workhorse core](https://workhorse.run/docs/installation)
+owns schema installation and changes.
+
 ## License
 
 Apache-2.0. See `LICENSE` and `NOTICE` in the package.

--- a/typescript/prisma/README.md
+++ b/typescript/prisma/README.md
@@ -29,10 +29,11 @@ await prisma.$transaction(async (tx) => {
 
 ## Package boundary
 
-The adapter never disconnects a caller-owned Prisma client unless `close` is configured. Workhorse
-core owns schema installation and changes. Pass a `pg` pool as `notificationPool` for
-`LISTEN/NOTIFY`; otherwise workers poll. Database errors become `PrismaQueryError`, with the original
-error in `cause` and a nested PostgreSQL code copied to `code` when Prisma exposes one.
+The adapter never disconnects a caller-owned Prisma client unless `close` is configured.
+[Workhorse core](https://workhorse.run/docs/installation) owns schema installation and changes.
+Pass a `pg` pool as `notificationPool` for `LISTEN/NOTIFY`; otherwise workers poll. Database errors
+become `PrismaQueryError`, with the original error in `cause` and a nested PostgreSQL code copied to
+`code` when Prisma exposes one.
 
 ## Next
 

--- a/typescript/typeorm/README.md
+++ b/typescript/typeorm/README.md
@@ -29,10 +29,11 @@ await dataSource.transaction(async (manager) => {
 
 ## Package boundary
 
-The adapter never destroys a caller-owned data source unless `close` is configured. Workhorse core
-owns schema installation and changes. Pass a `pg` pool as `notificationPool` for `LISTEN/NOTIFY`;
-otherwise workers poll. Database errors become `TypeOrmQueryError`, with the original error in `cause`
-and its PostgreSQL driver code copied to `code` when available.
+The adapter never destroys a caller-owned data source unless `close` is configured.
+[Workhorse core](https://workhorse.run/docs/installation) owns schema installation and changes.
+Pass a `pg` pool as `notificationPool` for `LISTEN/NOTIFY`; otherwise workers poll. Database errors
+become `TypeOrmQueryError`, with the original error in `cause` and its PostgreSQL driver code copied
+to `code` when available.
 
 ## Next
 


### PR DESCRIPTION
Closes WH-536.

Only the TypeScript package ships the schema SQL, so a Python or Go application installs it with the
Node CLI. Both READMEs said "with the TypeScript CLI" and named neither the command nor the
requirement, leaving a reader to guess at the one step that must happen before any process starts.

## What changed

- `python/README.md` and `go/README.md` state three facts in order: the schema is a deployment step
  the application never runs, the exact `support.json` command, and the Node floor for the machine
  that runs it.
- Seven add-on READMEs carry one linked sentence naming core as the schema owner. None carries a
  schema command.
- `api.mdx` states the npx invocation once and lists the subcommands under it, instead of repeating
  the full invocation on six lines. The example arguments the code block carried move into the list.
- `installation.mdx` and `quickstart.mdx` say on the Python and Go paths that the application never
  installs the schema. `quickstart.mdx` also lost a hand-written `Node.js 22+`.

## Where the version number lives

WH-537, and now WH-562, make the installation page fail on any support floor, because Compatibility
owns the numbers. So the fact is split by surface:

- Site pages state no number and link `[Compatibility](/docs/compatibility)`.
- `python/README.md` and `go/README.md` render on PyPI and pkg.go.dev, where a link is a worse
  answer than the floor. `support-matrix.test.ts` builds their sentence from `support.json`, so
  raising the floor moves both READMEs or fails.

## Enforcement

Two new checks, both failing before this change:

- The install sweep governs the schema command on `python/README.md` and `go/README.md`.
- A new case requires the linked core sentence on every published package README except core, and
  no schema command on any of them. Compared over collapsed whitespace, so rewrapping a paragraph
  cannot fail the rule. It caught three READMEs while I was writing them.

## Verification

`pnpm typecheck`, `pnpm lint`, and `pnpm format:check` pass. Targeted: 49 passed across
`support-matrix`, `install-commands`, and `readme-alignment`.

Each `pnpm test` tier observed green — vitest 1654 passed, python 155 passed, go ok. No single
end-to-end run went green: five runs each failed a different timing-sensitive integration test, and
every one passed in isolation immediately after. The machine was carrying a load average of 23.8
with 14 vitest and 5 `go test` processes from sibling worktrees on the same PostgreSQL server. This
change adds no runtime code — eleven Markdown and MDX files plus two test files — so no failing test
imports anything it modifies. Detail is in the WH-536 verification comment.

https://claude.ai/code/session_01BSiceoB5176Ua3VmwDo6uA
