### PR TITLE
[WH-545] Give transactional enqueue its Psycopg and pgx sections

### DIFF
--- a/docs/guides/200-transactional-enqueue.md
+++ b/docs/guides/200-transactional-enqueue.md
@@ -32,10 +32,50 @@ try {
 `Queue.enqueueMany` takes the same transaction argument, so a fan-out created by one request
 commits or rolls back as a unit with the row that caused it.
 
+## With Psycopg
+
+Python has no transaction argument. `Queue` binds the connection you give it, and the transaction
+belongs to that connection. Open a transaction on the connection, enqueue through a `Queue` built
+on the same connection, and the two writes share it:
+
+```python
+with connection.transaction():
+    connection.execute("INSERT INTO account (id, email) VALUES (%s, %s)", (id, email))
+    Queue(connection).enqueue("account.created", {"accountId": id})
+```
+
+If the block raises, Psycopg rolls back, and the job goes with your row.
+
+A worker needs a connection of its own, in autocommit mode. `Worker` raises `ValueError` if you
+hand it anything else, so that mistake is loud. The quiet mistake is sharing one connection between
+a worker and the code that enqueues: a Psycopg connection serializes its work, so the two take
+turns instead of running together, and nothing reports it. Give each its own connection.
+
+Autocommit and an explicit transaction are not in conflict. `connection.transaction()` opens a real
+transaction block on an autocommit connection, which is why the example above is correct on the same
+connection style a worker requires.
+
+## With pgx
+
+Go has no transaction argument either. An executor wraps whatever you already hold, and
+`NewPGXExecutor` accepts a `pgx.Tx` as readily as a pool:
+
+```go
+tx, err := pool.Begin(ctx)
+_, err = tx.Exec(ctx, "INSERT INTO account (id, email) VALUES ($1, $2)", id, email)
+queue := workhorse.NewQueue(workhorse.NewPGXExecutor(tx), "default")
+_, err = queue.Enqueue(ctx, "account.created", map[string]any{"accountId": id})
+err = tx.Commit(ctx)
+```
+
+`NewSQLExecutor` does the same for the standard library, and accepts a `*sql.Tx`. Either way the
+queue reads and writes through the handle you passed, so your commit covers the job.
+
 ## With an ORM provider
 
-If your application talks to PostgreSQL through an ORM, use that ORM's Workhorse package
-instead of managing a raw client next to it. Each provider wraps the database object you
+If your TypeScript application talks to PostgreSQL through an ORM, use that ORM's Workhorse
+package instead of managing a raw client next to it. Python and Go have no equivalent package, so
+they pass their own connection or transaction as the sections above show. Each provider wraps the database object you
 already own and exposes `forTransaction`, which returns a `Queue` bound to your open
 transaction. The provider never commits, rolls back, or closes that transaction — your ORM
 stays in charge, and Workhorse rides along on the transaction's own connection.

--- a/site/content/docs/enqueue.mdx
+++ b/site/content/docs/enqueue.mdx
@@ -84,9 +84,13 @@ Each option is owned by its own page — [retries](/docs/retries), [deadlines](/
 
 ## Join an application transaction
 
-This is the option that replaces an outbox. Pass your open transaction client as the fourth
-argument and PostgreSQL commits the job and your business write together — or rolls both back
-together. There is no window where one exists without the other.
+This is the option that replaces an outbox. Hand the queue the transaction you already opened and
+PostgreSQL commits the job and your business write together — or rolls both back together. There is
+no window where one exists without the other.
+
+Each language hands it over differently. TypeScript passes the transaction client as the fourth
+argument to `enqueue`. Python builds a `Queue` on the connection whose transaction is open. Go wraps
+the transaction in an executor and builds a `Queue` around that.
 
 <Tabs items={["TypeScript", "Python", "Go"]}>
   <Tab value="TypeScript">
@@ -115,8 +119,11 @@ together. There is no window where one exists without the other.
   </Tab>
 </Tabs>
 
-The fourth argument accepts anything with a pg-compatible `query` method, so the ORM adapters
-pass their own transaction handles the same way.
+TypeScript's fourth argument accepts anything with a pg-compatible `query` method, so the ORM
+adapters pass their own transaction handles the same way. Go's `NewPGXExecutor` accepts a `pgx.Tx`
+and `NewSQLExecutor` accepts a `*sql.Tx`. Python's `Worker` needs its own connection in autocommit
+mode and raises `ValueError` otherwise, so keep the connection you enqueue on separate from the one
+a worker runs on.
 
 One boundary to keep in mind: the transaction covers durable acceptance only. Handlers run later,
 outside your transaction, so their external effects still need their own idempotency.


### PR DESCRIPTION
Executes the decision recorded on WH-544, from [ADR 0049](docs/decisions/0049-publish-one-agent-documentation-layer.md).

## The gap

`docs/guides/200-transactional-enqueue.md` owns transactional enqueue for the guide layer, and its title is language-neutral. Its body was not: two sections, "With node-postgres" and "With an ORM provider", the second being four TypeScript ORMs. A Python or Go reader who followed the guide layer to this concept's owner found nothing in their language.

`site/content/docs/enqueue.mdx` was further ahead but said the wrong thing around the right code. It showed all three languages under "Join an application transaction" with correct tabs, while the prose described only the TypeScript signature:

- *"Pass your open transaction client as the fourth argument"*
- *"The fourth argument accepts anything with a pg-compatible `query` method"*

Neither Python nor Go has a fourth argument. Python binds the connection when it constructs `Queue(connection)`. Go wraps the transaction in `NewPGXExecutor(tx)`. An agent reading the prose and either of those tabs was told two different APIs in one section.

## The change

The guide gains **With Psycopg** and **With pgx** sections, and the ORM section now says it is about TypeScript and points the other two languages at theirs. The enqueue page states ownership per language instead of naming an argument position that exists in one.

The guide also carries the two Python facts that appeared in no guide: `Worker` needs its own connection in autocommit mode, which is loud because it raises; and sharing one connection between a worker and an enqueue is quiet, because a Psycopg connection serializes and the two take turns with nothing reported.

## Verification

Both examples were run against a real database, not written from memory, per the `AGENTS.md` rule.

```
Python  after commit   -> job rows: 1, account rows: 1
        after rollback -> job rows: 0, account rows: 0
Go      after commit   -> job rows: 1, account rows: 1
        after rollback -> job rows: 0, account rows: 0
```

`site-guide-coverage.test.ts` then caught `ValueError` named in the guide and absent from its mapped page, so the page names it too and the error is greppable from either layer.

`pnpm typecheck`, `pnpm lint`, and the site guide-coverage suite pass.

## Scope held

No new page, per the one-owner rule. No Python or Go page under Integrations: those four pages exist to unwrap a TypeScript ORM's transaction handle, and there is nothing verified to unwrap in Python or Go today. SQLAlchemy is deliberately absent and tracked as WH-546, because it cannot be verified in this checkout.

Closes WH-545.

https://claude.ai/code/session_01Ng3CpDEyGyEnMKcGcqCMBg