### PR TITLE
[WH-533] Rewrite the agent integration playbook and its guide

### DIFF
--- a/docs/guides/385-agent-integration.md
+++ b/docs/guides/385-agent-integration.md
@@ -1,35 +1,51 @@
 # How does an AI coding agent integrate Workhorse?
 
-An AI coding agent needs a short path from product documentation to verified application code.
-Workhorse publishes agent-readable documentation and keeps the same workflow across every SDK.
+An AI coding agent reads documentation by fetching URLs. It cannot click a language tab, so an
+HTML page hides two of the three languages from it. Workhorse publishes an agent-facing layer that
+solves discovery first, then walks one integration end to end.
 
-## Find the right documentation
+## Read the Markdown, not the HTML
 
-Start with `/llms.txt` for the documentation map. Use `/llms-full.txt` when the agent needs the
-complete documentation in one request. Every documentation page also has a Markdown twin, and the
-HTML response advertises that twin through its alternate link.
+Append `.md` to any documentation URL to reach that page's Markdown twin. The twin shows every
+language at once, because it expands each language tab inline. The suffix is the only route; asking
+for Markdown through content negotiation does not work.
 
-The Markdown pages preserve code and identifiers without requiring the agent to extract an HTML
-shell. Give the agent the narrow page first, then use the full index when the task crosses several
-features.
+Two index files sit above the twins. One is a compact map of every page, grouped like the sidebar.
+The other is the whole corpus in a single response, which is large and worth fetching only when a
+change crosses several contracts at once.
+
+## Decide before you integrate
+
+The playbook states what Workhorse is not, before it shows any code, so an agent can stop early
+rather than discover a mismatch after writing the integration. Handlers run at least once. Schema
+compatibility is exact. PostgreSQL is the only database. There is no workflow definition language.
 
 ## Follow one integration path
 
-Install the SDK for the application's language, then construct `Queue` over the application's
-PostgreSQL connection. Enqueue inside the transaction that changes application data, so PostgreSQL
-commits the job and that data together.
+The agent writes four things. It installs the schema from the deployment rather than from the
+application. It enqueues inside the transaction that writes application data, so both commit
+together. It registers a handler. It chooses the failure policy when it enqueues.
 
-Run a `Worker` with a handler for the same job type. After the worker settles the job, use
-`Admin.getJob`, `Admin.get_job`, or `Admin.GetJob` to confirm its durable state and result.
+Three mistakes survive review because none of them fails immediately. Enqueueing outside the
+caller's transaction leaves a job for a row that rolled back. Installing the schema at startup makes
+every instance race. An external effect that is not restart-safe repeats on every retry, which a
+checkpoint prevents by recording the result the first time.
 
-The site page shows complete TypeScript, Python, and Go programs. The repository verifies their
-public names against the SDK sources and compiles the Python and Go examples during site checks.
+After the worker settles the job, the agent reads it back by its identifier to confirm the durable
+state and result.
+
+## How the examples stay true
+
+The site page carries one complete program per language. Site checks compile all three: TypeScript
+through the type checker, Python through the formatter and the type checker, and Go through the
+formatter and the compiler. The cross-SDK name sweep that guards the feature pages does not cover
+this page, because compiling its programs is the stronger check.
 
 ## Next
 
 - [200-transactional-enqueue.md](200-transactional-enqueue.md) — commit application data and work together
 - [310-workers.md](310-workers.md) — run handlers as a supervised process
-- [395-serverless-web-tiers.md](395-serverless-web-tiers.md) — enqueue from short-lived request handlers
+- [030-delivery-guarantees.md](030-delivery-guarantees.md) — why a handler must tolerate running twice
 
 ---
 

--- a/site/content/docs/for-ai-agents.mdx
+++ b/site/content/docs/for-ai-agents.mdx
@@ -1,34 +1,92 @@
 ---
 title: Workhorse for AI coding agents
-description: Find agent-readable documentation, then integrate one transactional job from enqueue through confirmation.
+description: Read the agent-facing documentation, decide whether Workhorse fits, then integrate one transactional job from enqueue through confirmation.
 ---
 
-Workhorse gives an AI coding agent a direct path from documentation discovery to verified
-application code. Start with the narrowest useful Markdown source, then follow the same integration
-sequence in TypeScript, Python, or Go.
+You are integrating Workhorse into someone else's application. This page is the whole integration:
+what to read, whether to stop, the four things you write, the three mistakes that survive review,
+and how to confirm the job settled.
 
-## Read the documentation without an HTML shell
+## How to read this documentation
 
-- Fetch `/llms.txt` for a compact map of every documentation page, grouped like the sidebar.
-- Fetch `/llms-full.txt` when the task needs the complete documentation corpus in one response.
-- Append `.md` to a page URL for its Markdown twin, such as `/docs/enqueue.md`.
-- When the agent starts from HTML, follow the response's `text/markdown` alternate link to the same
-  page's Markdown twin.
+Append `.md` to any documentation URL for its Markdown twin, such as `/docs/enqueue.md`. Read the
+twin, not the HTML page. A Markdown twin shows every language; the HTML page shows one, because its
+language tabs collapse to whichever tab is selected. The suffix is the only route to the twin — a
+canonical HTML URL does not negotiate on `Accept`.
 
-Use the per-page twin for focused work because it spends less context. Use `/llms-full.txt` when a
-change crosses several contracts and the agent needs to search them together.
+Fetch `/llms.txt` for a compact map of every page, grouped like the sidebar. Fetch `/llms-full.txt`
+only when a change crosses several contracts at once and you need to search them together; it is
+large, and one twin is usually the cheaper read.
 
-## Integrate one job end to end
+## Whether Workhorse fits
 
-Install the SDK used by the application:
+Stop here if any of these is disqualifying. They are properties, not defects.
 
-- TypeScript: `npm install @stablemates/workhorse`
-- Python: `pip install stablemates-workhorse`
-- Go: `go get github.com/stablemates/workhorse/go`
+- Handlers run at least once. A retry can run your handler again, so its effects must tolerate that.
+- Schema compatibility is exact, and 0.x offers no upgrade path between minor releases.
+- PostgreSQL is the only supported database. There is no other backend.
+- There is no workflow definition language. You compose durable steps in your own code.
+- A concurrency policy is scoped to one queue, not across queues.
 
-Each complete example below opens PostgreSQL, enqueues `order.created` inside the transaction that
-inserts the order, runs a matching worker, and reads the durable result. Production processes call
-the worker's continuous run method; these bounded examples use one pass so they can finish.
+[Limitations](/docs/limitations.md) owns this subject, including the workarounds this page does not
+restate.
+
+## The four things you write
+
+**Install the schema from your deployment, never at application startup.** The schema is a
+deployment step:
+
+```bash
+npx --package @stablemates/workhorse workhorse schema install
+```
+
+That command needs Node.js on the machine that runs your deployment, and
+[Compatibility](/docs/compatibility.md) names the version. The application itself does not need
+Node: a Python or Go service installs the schema this way and then runs without it. Assert compatibility when the application starts, with `assertSchemaCompatible` in TypeScript,
+`assert_schema_compatible` in Python, or `AssertCompatible` in Go.
+
+Install the SDK your application uses:
+
+```bash
+npm install @stablemates/workhorse
+pip install stablemates-workhorse
+go get github.com/stablemates/workhorse/go
+```
+
+**Enqueue inside the transaction that writes your application data.** This is what replaces an
+outbox. Each language hands the transaction over differently: TypeScript passes the transaction
+client as the fourth argument to `enqueue`, Python constructs the `Queue` over the connection whose
+transaction is open, and Go wraps the transaction with `workhorse.NewPGXExecutor(tx)`.
+
+**Register a handler.** The example below calls the bounded run method so it can finish. A
+production worker process calls the continuous one instead: `worker.run()` in TypeScript,
+`worker.run()` in Python, and `worker.Run(ctx)` in Go.
+
+**Choose the failure policy at enqueue.** `maxAttempts` and `retryPolicy` set the retry budget.
+`deadline` and `executionTimeoutMs` are separate bounds, and each is terminal on its own even when
+retry budget remains.
+
+## The three mistakes
+
+**Enqueuing outside the caller's transaction.** The job commits even though the row rolled back, and
+a worker then processes an order that does not exist. The remedy is to pass the transaction, as the
+example does.
+
+**Installing the schema on the runtime path.** Every application instance races to install, and a
+version skew becomes a startup failure under load rather than a deployment failure. The remedy is
+the deployment command above, plus a compatibility assertion at startup.
+
+**An external effect that is not restart-safe.** A handler that sends before it finishes sends again
+on every retry. The remedy is `context.checkpoint(name, operation)` in TypeScript and Python, and
+`handler.Checkpoint(name, operation)` in Go: the operation runs once, and a replay reuses the
+recorded value instead of running it again. An idempotency key on the remote call, an outbox, an
+inbox, or a compensation path are the alternatives when a checkpoint does not fit.
+
+## One job, end to end
+
+Each example opens PostgreSQL, enqueues `order.created` inside the transaction that inserts the
+order, sets a failure policy, runs a worker whose handler wraps its external send in a checkpoint,
+and reads the durable result.
 
 <Tabs items={["TypeScript", "Python", "Go"]}>
   <Tab value="TypeScript">
@@ -40,10 +98,19 @@ the worker's continuous run method; these bounded examples use one pass so they 
     const client = await pool.connect();
     let jobId: string;
 
+    async function sendConfirmationEmail(orderId: string): Promise<string> {
+      return `receipt-for-${orderId}`;
+    }
+
     try {
       await client.query("BEGIN");
       await client.query("INSERT INTO orders (id, status) VALUES ($1, $2)", ["order-42", "new"]);
-      jobId = await queue.enqueue("order.created", { orderId: "order-42" }, {}, client);
+      jobId = await queue.enqueue(
+        "order.created",
+        { orderId: "order-42" },
+        { maxAttempts: 5, retryPolicy: { type: "fixed", delayMs: 1_000 } },
+        client,
+      );
       await client.query("COMMIT");
     } catch (error) {
       await client.query("ROLLBACK");
@@ -52,9 +119,16 @@ the worker's continuous run method; these bounded examples use one pass so they 
       client.release();
     }
 
-    const worker = new Worker(queue).handle("order.created", async (payload: { orderId: string }) => ({
-      processedOrderId: payload.orderId,
-    }));
+    const worker = new Worker(queue).handle(
+      "order.created",
+      async (payload: { orderId: string }, context) => {
+        // The send runs once. A replay reuses the recorded receipt.
+        const receipt = await context.checkpoint("confirmation-email", () =>
+          sendConfirmationEmail(payload.orderId),
+        );
+        return { processedOrderId: payload.orderId, receipt };
+      },
+    );
     await worker.runOnce(); // Production worker processes call worker.run().
 
     const job = await new Admin(pool).getJob(jobId);
@@ -66,12 +140,27 @@ the worker's continuous run method; these bounded examples use one pass so they 
   <Tab value="Python">
     ```python verify
     import os
+    from typing import Any
 
     import psycopg
 
-    from workhorse import Admin, Queue, Worker
+    from workhorse import Admin, EnqueueOptions, HandlerContext, Json, Queue, Worker
 
     database_url = os.environ["DATABASE_URL"]
+
+
+    def send_confirmation_email(order_id: str) -> str:
+        return f"receipt-for-{order_id}"
+
+
+    def handle_order_created(payload: Any, context: HandlerContext) -> Json:
+        # The send runs once. A replay reuses the recorded receipt.
+        receipt = context.checkpoint(
+            "confirmation-email",
+            lambda: send_confirmation_email(payload["orderId"]),
+        )
+        return {"processedOrderId": payload["orderId"], "receipt": receipt}
+
 
     with psycopg.connect(database_url) as application_connection:
         with application_connection.transaction():
@@ -82,13 +171,14 @@ the worker's continuous run method; these bounded examples use one pass so they 
             job_id = Queue(application_connection).enqueue(
                 "order.created",
                 {"orderId": "order-42"},
+                EnqueueOptions(
+                    max_attempts=5,
+                    retry_policy={"type": "fixed", "delayMs": 1_000},
+                ),
             )
 
     with psycopg.connect(database_url, autocommit=True) as worker_connection:
-        worker = Worker(worker_connection).handle(
-            "order.created",
-            lambda payload, _context: {"processedOrderId": payload["orderId"]},
-        )
+        worker = Worker(worker_connection).handle("order.created", handle_order_created)
         worker.run_once()  # Production worker processes call worker.run().
         job = Admin(worker_connection).get_job(job_id)
         print(job.state if job else None, job.result if job else None)
@@ -112,6 +202,10 @@ func main() {
 	if err := run(); err != nil {
 		panic(err)
 	}
+}
+
+func sendConfirmationEmail(orderID string) (any, error) {
+	return "receipt-for-" + orderID, nil
 }
 
 func run() error {
@@ -141,6 +235,10 @@ func run() error {
 		ctx,
 		"order.created",
 		map[string]any{"orderId": "order-42"},
+		workhorse.EnqueueOptions{
+			MaxAttempts: 5,
+			RetryPolicy: map[string]any{"type": "fixed", "delayMs": 1000},
+		},
 	)
 	if err != nil {
 		return err
@@ -156,11 +254,17 @@ func run() error {
 	worker.Handle("order.created", func(
 		_ context.Context,
 		payload any,
-		_ *workhorse.HandlerContext,
+		handler *workhorse.HandlerContext,
 	) (any, error) {
-		return map[string]any{
-			"processedOrderId": payload.(map[string]any)["orderId"],
-		}, nil
+		orderID := payload.(map[string]any)["orderId"].(string)
+		// The send runs once. A replay reuses the recorded receipt.
+		receipt, err := handler.Checkpoint("confirmation-email", func() (any, error) {
+			return sendConfirmationEmail(orderID)
+		})
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"processedOrderId": orderID, "receipt": receipt}, nil
 	})
 	if _, err = worker.RunOnce(ctx); err != nil { // Production workers call Run.
 		return err
@@ -178,20 +282,21 @@ func run() error {
   </Tab>
 </Tabs>
 
-The application transaction covers acceptance, so the order and job commit or roll back together.
-The handler runs later and may run again after a retry, so protect its external effects with an
-idempotency key, outbox, inbox, or compensation path.
+Two asymmetries to expect. Go's `RetryPolicy` is a `map[string]any` where TypeScript has a typed
+union, and Python's is a mapping, so only TypeScript rejects a malformed policy at compile time.
+Every language does have a schema compatibility assertion, named above.
 
-`Queue`, `Worker`, and `Admin` are the TypeScript names, including `Admin.getJob` for confirmation.
-Python keeps the types and uses snake-case methods such as `Admin.get_job`; Go uses
-`workhorse.NewQueue`, `workhorse.NewWorker`, and `workhorse.NewAdmin`, with methods such as
-`Admin.GetJob`.
+## Confirm the job settled
+
+Read the job back by its identifier: `Admin.getJob` in TypeScript, `Admin.get_job` in Python, and
+`Admin.GetJob` in Go, as each example does. A settled job reports its state and its result. Until
+then it reports the state it is in, which is how you tell a slow worker from a missing one.
 
 ## Next
 
-- [Agent workflows](/docs/agentic-flow) — compose durable model, tool, timer, and approval boundaries
-- [Enqueue a job](/docs/enqueue) — understand transaction and routing options
-- [Workers](/docs/workers) — run handlers continuously in production
+- [Enqueue a job](/docs/enqueue.md) — every transaction and routing option
+- [Workers](/docs/workers.md) — run handlers continuously in production
+- [Agent workflows](/docs/agentic-flow.md) — compose durable model, tool, timer, and approval boundaries
 
 ---
 

--- a/typescript/core/test/site-smoke.ts
+++ b/typescript/core/test/site-smoke.ts
@@ -58,7 +58,10 @@ try {
     ["/docs", ["Workhorse", "PostgreSQL"]],
     ["/docs/api", ["API overview", `Workhorse version ${WORKHORSE_VERSION}`]],
     ["/docs/for-ai-agents", ["TypeScript", "Python", "Go"]],
-    ["/docs/for-ai-agents.md", ["TypeScript", "Python", "Go"]],
+    // The playbook's remedy for a non-restart-safe external effect is a
+    // checkpoint. A rewrite that drops the word drops the one mistake a
+    // recorded baseline session actually made.
+    ["/docs/for-ai-agents.md", ["TypeScript", "Python", "Go", "checkpoint"]],
     ["/docs/integrations", ["Verified", "Documented", "Tested against drizzle-orm"]],
     ["/docs/integrations.md", ["ORMs and query builders", "Tested against drizzle-orm"]],
     ["/docs/quickstart", ["quickstart", "worker"]],
@@ -113,6 +116,23 @@ try {
     for (const token of tokens) {
       if (body.includes(token)) throw new Error(`${path} still carries the MDX tag ${token}`);
     }
+  }
+
+  // Every documentation link in the playbook must reach a twin, because the page
+  // is read by agents that cannot open a language tab. A link to the HTML page
+  // costs the reader two of its three languages, so assert the suffix and then
+  // prove each target actually resolves.
+  const playbook = await (await fetch(`${baseUrl}/docs/for-ai-agents.md`)).text();
+  const playbookLinks = [...playbook.matchAll(/\]\((\/docs\/[^)\s]+)\)/g)].map((match) => match[1]!);
+  if (playbookLinks.length === 0) {
+    throw new Error("The agent playbook carried no documentation links to check");
+  }
+  for (const link of playbookLinks) {
+    if (!link.endsWith(".md")) {
+      throw new Error(`The agent playbook links ${link}, which is not a Markdown twin`);
+    }
+    const linked = await fetch(`${baseUrl}${link}`);
+    if (!linked.ok) throw new Error(`The agent playbook links ${link}, which returned ${linked.status}`);
   }
 
   // Expanding the tabs cost no size, because the twins already carried all three

--- a/typescript/core/test/site-smoke.ts
+++ b/typescript/core/test/site-smoke.ts
@@ -123,7 +123,9 @@ try {
   // costs the reader two of its three languages, so assert the suffix and then
   // prove each target actually resolves.
   const playbook = await (await fetch(`${baseUrl}/docs/for-ai-agents.md`)).text();
-  const playbookLinks = [...playbook.matchAll(/\]\((\/docs\/[^)\s]+)\)/g)].map((match) => match[1]!);
+  const playbookLinks = [...playbook.matchAll(/\]\((\/docs\/[^)\s]+)\)/g)].map(
+    (match) => match[1]!,
+  );
   if (playbookLinks.length === 0) {
     throw new Error("The agent playbook carried no documentation links to check");
   }
@@ -132,7 +134,8 @@ try {
       throw new Error(`The agent playbook links ${link}, which is not a Markdown twin`);
     }
     const linked = await fetch(`${baseUrl}${link}`);
-    if (!linked.ok) throw new Error(`The agent playbook links ${link}, which returned ${linked.status}`);
+    if (!linked.ok)
+      throw new Error(`The agent playbook links ${link}, which returned ${linked.status}`);
   }
 
   // Expanding the tabs cost no size, because the twins already carried all three


### PR DESCRIPTION
Executes WH-533, decided by WH-522 and recorded as [ADR 0049](docs/decisions/0049-publish-one-agent-documentation-layer.md).

`site/content/docs/for-ai-agents.mdx` is rewritten in place, and `docs/guides/385-agent-integration.md` is rewritten to track it in the same commit, because `site/guide-coverage.json` maps the two and `AGENTS.md` requires both layers to move together. The page keeps its URL.

## What was wrong

The page named `checkpoint` **zero times** and mentioned the schema step in no language. An agent that followed it alone ran the code examples against an empty database, and had no remedy named for the one mistake a recorded baseline session actually made.

## The six sections

How to read this documentation · Whether Workhorse fits · The four things you write · The three mistakes · Confirm the job settled · Next.

"Whether Workhorse fits" comes before any code so an agent can stop early. It states five properties in one clause each and links to `/docs/limitations.md`, which owns the subject and whose workarounds this page does not restate.

## The example grew the remedy

The single end-to-end example is the page's whole verification surface, so mistake 3's remedy lives inside it. Each language wraps a local `sendConfirmationEmail` in a checkpoint and sets a failure policy at enqueue. The external effect is a function defined in the snippet, not an HTTP client: the three fences are compile gates, and a network dependency would add a shape to that gate for no teaching value.

Accepted consequence: the Python handler stops being a lambda and becomes a named function, because it now uses its context.

## Facts checked against the source, not taken from the ticket

- **Python does export `assert_schema_compatible`** (`python/src/workhorse/__init__.py:236`). The ticket asked me to verify this at time of writing; all three languages have a compatibility assertion, and the page says so.
- **Python's `RetryPolicy` is `Mapping[str, Json]`**, not a typed union. The ticket said TypeScript and Python both had typed unions and only Go was untyped. Only TypeScript rejects a malformed policy at compile time, and the page states that.
- **The schema step links to Compatibility rather than naming the Node version.** The ticket asked for "Node.js 22 or newer", but `installation.mdx` reserves version naming to `/docs/compatibility`, and WH-537 has just removed restated floors elsewhere. Following the newer rule.
- **Guide 385's claim that the repository "verifies their public names against the SDK sources" is false** and is removed. `for-ai-agents.mdx` is not in `crossSdkGuidePaths`, so the name sweep does not reach it; its programs are compiled instead, which is stronger but different.

## Verification

All four install commands appear verbatim from the `install` catalog in `support.json`, and the page states no version. Every `/docs/` link in the body ends in `.md`. The generated twin expands all three languages under bold labels, carries no surviving MDX tag, and names `checkpoint`.

`site-smoke.ts` now asserts the twin names `checkpoint`, and that every `/docs/` link in the page ends in `.md` and returns 200.

**Caveat, recorded on the Issue:** `test:site-smoke` runs in no enabled CI lane (`.github/workflows/ci.yml:312` carries `if: ${{ false }}`), so that assertion is real but ungated.

`pnpm typecheck` passes, which runs `check-language-examples.ts` and compiles all three fences. `pnpm lint` and the site guide-coverage suite pass.

## Known gap, not closed here

The three mistakes are named, not proven. Nothing executes a program that enqueues outside the transaction to show the job surviving a rollback. That harness has its own Issue.

Closes WH-533.

https://claude.ai/code/session_01Ng3CpDEyGyEnMKcGcqCMBg