### PR TITLE
[WH-530] Give llms.txt an agent-facing lead

### DIFF
--- a/site/scripts/gen-docs-index.ts
+++ b/site/scripts/gen-docs-index.ts
@@ -482,9 +482,27 @@ await Promise.all(
 );
 
 /**
- * `/llms.txt`, the index an agent reads before fetching anything. It mirrors
- * the sidebar, so the grouping a human sees and the grouping an agent sees
- * cannot drift apart.
+ * The page an agent starts at, and the page whose install commands it copies.
+ * `llms.txt` names both above the fold, so each slug is resolved against
+ * `pages` and the build fails rather than routing an agent to a page nobody
+ * ships.
+ */
+const entryPointSlug = "for-ai-agents";
+const installationSlug = "installation";
+
+const routerPage = (slug: string): PageRecord => {
+  const page = pages.get(slug);
+  if (!page) throw new Error(`The router names "${slug}", which has no file in content/docs`);
+  return page;
+};
+const entryPoint = routerPage(entryPointSlug);
+const installation = routerPage(installationSlug);
+
+/**
+ * `/llms.txt`, the index an agent reads before fetching anything. Its lead is
+ * free-form prose above the first `##`; the `##` sections mirror the sidebar,
+ * so the grouping a human sees and the grouping an agent sees cannot drift
+ * apart.
  */
 const llmsSection = (group: Group, depth = 2): string => {
   const heading = "#".repeat(depth);
@@ -496,27 +514,14 @@ const llmsSection = (group: Group, depth = 2): string => {
   return [`${heading} ${group.title}`, "", ...lines, "", ...nested].join("\n");
 };
 
-await writeFile(
-  new URL("../public/llms.txt", import.meta.url),
-  `# ${siteConfig.name}
-
-> ${siteConfig.description}
-
-Every page below is available as Markdown by appending \`.md\` to its URL.
-For the complete documentation in one file, read [llms-full.txt](${base}/llms-full.txt).
-
-${structure.map((group) => llmsSection(group)).join("\n")}
-## Optional
-
-- [Repository](${siteConfig.github})
-- [npm](${siteConfig.npm})
-`,
-);
-
 /**
  * `/llms-full.txt`, every page in sidebar order. The separator and canonical
  * URL identify each page, and the document that follows is the same body the
  * standalone twin carries, without the twin's frontmatter.
+ *
+ * It is built before `llms.txt` is written, because the router states this
+ * file's size and reads the number from the string as written rather than
+ * from a figure someone typed.
  */
 const llmsFullSection = (group: Group, depth = 2): string => {
   const heading = "#".repeat(depth);
@@ -530,16 +535,50 @@ const llmsFullSection = (group: Group, depth = 2): string => {
   return [`${heading} ${group.title}`, "", ...documents, "", ...nested].join("\n");
 };
 
+/**
+ * The full file's lead is its own, not a copy of the router's. An agent holding
+ * this file has already fetched everything, so routing it is a no-op; what it
+ * still needs is where the index lives and how to install.
+ */
+const llmsFull = `# ${siteConfig.name}
+
+> ${siteConfig.description}
+
+This file is every documentation page in one download. For the page index and the Markdown URLs,
+read [llms.txt](${base}/llms.txt).
+
+Install with the commands under ${installation.title} below. They name no version, and the runtime
+compatibility check confirms the schema before a process starts.
+
+${structure.map((group) => llmsFullSection(group)).join("\n")}`;
+
+const llmsFullKilobytes = Math.round(Buffer.byteLength(llmsFull, "utf8") / 1000);
+
 await writeFile(
-  new URL("../public/llms-full.txt", import.meta.url),
+  new URL("../public/llms.txt", import.meta.url),
   `# ${siteConfig.name}
 
 > ${siteConfig.description}
 
-For the concise documentation index, read [llms.txt](${base}/llms.txt).
+Start at [${entryPoint.title}](${base}${entryPoint.url}.md). ${entryPoint.description}
 
-${structure.map((group) => llmsFullSection(group)).join("\n")}`,
+Append \`.md\` to any page URL for its Markdown source. A Markdown page shows all three languages
+where the HTML page shows one.
+
+Install with the commands on [${installation.title}](${base}${installation.url}.md). They name no
+version, and the runtime compatibility check confirms the schema before a process starts.
+
+[llms-full.txt](${base}/llms-full.txt) is every page below in one file, about ${llmsFullKilobytes} KB.
+
+${structure.map((group) => llmsSection(group)).join("\n")}
+## Optional
+
+- [Repository](${siteConfig.github})
+- [npm](${siteConfig.npm})
+`,
 );
+
+await writeFile(new URL("../public/llms-full.txt", import.meta.url), llmsFull);
 
 // The search index is derived data. Crawling it wastes budget. Markdown twins
 // are not derived: they are the same content in a form an agent can read, so

--- a/typescript/core/test/site-smoke.ts
+++ b/typescript/core/test/site-smoke.ts
@@ -10,7 +10,7 @@ const baseUrl = `http://127.0.0.1:${port}`;
 
 function assertIncludesTokens(body: string, page: string, tokens: readonly string[]): void {
   for (const token of tokens) {
-    if (!body.includes(token)) throw new Error(`${page} omitted SEO token ${token}`);
+    if (!body.includes(token)) throw new Error(`${page} omitted required token ${token}`);
   }
 }
 
@@ -118,13 +118,31 @@ try {
   // Expanding the tabs cost no size, because the twins already carried all three
   // languages and de-indenting the fences gave a little back. The bound catches a
   // generator that starts repeating content, not ordinary growth.
-  const llmsFullBytes = Buffer.byteLength(
-    await (await fetch(`${baseUrl}/llms-full.txt`)).text(),
-    "utf8",
-  );
+  const llmsFullText = await (await fetch(`${baseUrl}/llms-full.txt`)).text();
+  const llmsFullBytes = Buffer.byteLength(llmsFullText, "utf8");
   if (llmsFullBytes > 320_000) {
     throw new Error(`llms-full.txt grew to ${llmsFullBytes} bytes, well past its 256 KB shape`);
   }
+
+  // The router's lead is the prose above its first `##`. It has to name the
+  // entry point, the `.md` rule, and the Installation page, and the size it
+  // states for `llms-full.txt` has to be the size the file actually has, so a
+  // generator that types the number instead of measuring it fails here.
+  const llmsLead = (await (await fetch(`${baseUrl}/llms.txt`)).text()).split("\n## ")[0]!;
+  assertIncludesTokens(llmsLead, "The llms.txt lead", [
+    "https://workhorse.run/docs/for-ai-agents.md",
+    "Append `.md` to any page URL",
+    "https://workhorse.run/docs/installation.md",
+    `about ${Math.round(llmsFullBytes / 1000)} KB`,
+  ]);
+  // The full file carries its own lead rather than a copy of the router's: it
+  // points back at the index and states the version rule for the install
+  // commands it contains.
+  assertIncludesTokens(llmsFullText.split("\n## ")[0]!, "The llms-full.txt lead", [
+    "every documentation page in one download",
+    "https://workhorse.run/llms.txt",
+    "name no version",
+  ]);
 
   const landingHtml = await (await fetch(`${baseUrl}/`)).text();
   assertIncludesTokens(landingHtml, "The landing page", [


### PR DESCRIPTION
llms.txt was a sidebar mirror with a two-line preamble, so an agent that found it learned
nothing it did not already have. Two of four baseline sessions never found the agent page,
three lost two of three languages to collapsed HTML tabs, and one invented a version.

The router now carries a four-paragraph lead above its first `##`: start at the agent page,
append `.md` for the Markdown source that shows all three languages, install with the
commands on Installation, and what llms-full.txt costs. Each paragraph states the target
behaviour; none names the mistake it exists to prevent. The `##` sections stay the sidebar
mirror, so the human grouping and the agent grouping still cannot drift.

llms-full.txt gets its own two-paragraph lead rather than a copy: an agent holding it has
already fetched everything, so it needs the index and the version rule, not a route.

The version paragraph follows WH-523, not the WH-521 draft. Installation no longer prints a
version, so both leads say the commands name none and the runtime check confirms the schema.

The generator builds the full body before writing llms.txt and interpolates its size,
rounded to the nearest 1000 bytes, from the string as written. The entry-point and
Installation slugs are named constants resolved against `pages`, so a renamed page fails
the build with the slug in the message instead of routing an agent to a 404.

The smoke test asserts the router lead names the entry point, the `.md` rule, and the
Installation URL, that the stated size equals the fetched file's size, and that
llms-full.txt carries its own lead.

Closes WH-530. Verified: `pnpm test:site-smoke` passed (docs build + smoke, including the new lead assertions), `pnpm typecheck`, `pnpm format:check`, and `oxlint` on both files clean. Breaking the entry-point constant fails the generator with the slug in the message.

https://claude.ai/code/session_01BSiceoB5176Ua3VmwDo6uA