### PR TITLE
[WH-568] Date the published beta entries in all three changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ including changing the schema. There is no upgrade path between 0.x releases: mo
 requires a fresh database. Ordered, immutable migrations begin at 1.0.0. Breaking changes are
 always listed with upgrade steps.
 
-## 0.1.0-beta.2 — unreleased
+## 0.1.0-beta.2 — 2026-09-01
+
+Published to npm from commit `856cdcf354aa83a3acf8ee67043145adb9c99e09`, tagged
+`v0.1.0-beta.2`.
 
 First published line. Requires **schema v1**, Node.js **22 or 24**, PostgreSQL **15 through 18**.
 
@@ -128,9 +131,9 @@ First published line. Requires **schema v1**, Node.js **22 or 24**, PostgreSQL *
 
 ### Changed
 
-The line is unreleased, so these changes precede first publication and no deployment upgrades
-through them. They are recorded because the pre-release dashboards and ADRs in this repository
-name the retired instruments.
+These changes precede the first publication, so no deployment upgrades through them. They are
+recorded because the pre-release dashboards and ADRs in this repository name the retired
+instruments.
 
 - **Breaking:** `@stablemates/workhorse` now publishes only the `workhorse` binary. Replace
   `workhorse-health`, `workhorse-bench`, and `workhorse-bench-competitors` with `workhorse health`,

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -194,23 +194,34 @@ for the distribution being published.
 
 ### First public beta release train
 
-The first public beta publishes from one source commit during one controlled release window. It is
-a staged release rather than a concurrent one:
+The first public beta was planned to publish from one source commit during one controlled release
+window. It was a staged release rather than a concurrent one, and fix-forwards moved it across three
+source commits. This is how it ran:
 
-1. Require a green public CI run for the candidate commit. Dispatch `.github/workflows/release.yml`
-   and `.github/workflows/release-python.yml` manually with `dry-run` enabled.
-2. Download and inspect every npm and Python archive. Install all nine npm tarballs, the Python
-   wheel, and the Python source distribution in clean consumers. Build the Go external consumer
-   from the same commit. Test registries are not part of the rehearsal.
-3. Publish Python first. `0.1.0b1` and `0.1.0b2` remain public without provenance. Verify the
-   fix-forward `0.1.0b3` release through PyPI before continuing.
-4. Publish npm second. Publish `@stablemates/workhorse` before its eight dependents, and verify
-   every `0.1.0-beta.2` package before continuing. The `0.1.0-beta.1` tag stopped before its first
-   registry upload and remains unpublished.
-5. Publish Go last. Verify `go/v0.1.0-beta.1` through the public module proxy.
+1. Rehearsal required a green public CI run for the candidate commit. `.github/workflows/release.yml`
+   and `.github/workflows/release-python.yml` were dispatched manually with `dry-run` enabled. Every
+   npm and Python archive was downloaded and inspected. All nine npm tarballs, the Python wheel, and
+   the Python source distribution were installed in clean consumers, and the Go external consumer
+   was built from the same commit. Test registries are not part of the rehearsal.
+2. Publish Python first. `0.1.0b1` published from `6769c768d19861fb8c5c7ea3764e8d5abc62fcf4` and
+   `0.1.0b2` from `0c15212cc5510501bbc9b74bd372fa480e77a1ff` on 2026-08-31. The workflow generated
+   PEP 740 attestations for both but omitted them from the upload, so both remain public without
+   provenance. The fix-forward `0.1.0b3` published from `663c526805746786f12b3be3e151e8ce06c80057`
+   on 2026-09-01 with attestations and was verified through PyPI before the train continued.
+3. Publish npm second. The `v0.1.0-beta.1` tag on `756c3ae1f73e7481ba065fefd35c051107ee614a`
+   stopped before its first registry upload because npm parsed a relative tarball path as GitHub
+   shorthand; it remains unpublished. The fix-forward `0.1.0-beta.2` published all nine packages
+   from `856cdcf354aa83a3acf8ee67043145adb9c99e09` on 2026-09-01, `@stablemates/workhorse` before
+   its eight dependents, and every package was verified before the train continued.
+4. Publish Go last. `go/v0.1.0-beta.1` published from `dbd5437362930f712157ffcc72c3296e971e4f5a` on
+   2026-09-01 and was verified through the public module proxy.
 
-Each verification checks registry visibility, provenance or the module checksum, and installation
-of the exact public version in a clean environment. It then runs a minimal enqueue-and-worker smoke
+The three published versions therefore come from three source commits rather than one. Each source
+commit is on `main` and had a green public CI run. The dated entries in `CHANGELOG.md`,
+`python/CHANGELOG.md`, and `go/CHANGELOG.md` name the same commits.
+
+Each verification checked registry visibility, provenance or the module checksum, and installation
+of the exact public version in a clean environment. It then ran a minimal enqueue-and-worker smoke
 test against a fresh PostgreSQL database. Any failure stops the release train.
 
 A published version is never reused. An ordinary defect stays available and receives a higher

--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -6,7 +6,10 @@ releases independently from the TypeScript packages and the Python distribution.
 Workhorse is a public beta. Any 0.x minor release may break compatibility, including the schema.
 There is no upgrade path between 0.x releases; ordered migrations begin at 1.0.0.
 
-## 0.1.0-beta.1 — unreleased
+## 0.1.0-beta.1 — 2026-09-01
+
+Published through the Go module proxy from commit `dbd5437362930f712157ffcc72c3296e971e4f5a`,
+tagged `go/v0.1.0-beta.1`.
 
 ### Changed
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,7 +6,10 @@ releases independently from the TypeScript packages and the Go module.
 Workhorse is a public beta. Any 0.x minor release may break compatibility, including the schema.
 There is no upgrade path between 0.x releases; ordered migrations begin at 1.0.0.
 
-## 0.1.0b3 — unreleased
+## 0.1.0b3 — 2026-09-01
+
+Published to PyPI from commit `663c526805746786f12b3be3e151e8ce06c80057`, tagged
+`python/v0.1.0b3`.
 
 ### Fixed
 
@@ -20,12 +23,18 @@ There is no upgrade path between 0.x releases; ordered migrations begin at 1.0.0
 
 ## 0.1.0b2 — 2026-08-31
 
+Published to PyPI from commit `0c15212cc5510501bbc9b74bd372fa480e77a1ff`, tagged
+`python/v0.1.0b2`.
+
 ### Fixed
 
 - The release workflow generated PEP 740 attestations but omitted them from the PyPI upload.
   The package behavior is unchanged from `0.1.0b1`.
 
 ## 0.1.0b1 — 2026-08-31
+
+Published to PyPI from commit `6769c768d19861fb8c5c7ea3764e8d5abc62fcf4`, tagged
+`python/v0.1.0b1`.
 
 ### Changed
 

--- a/scripts/public-beta-release.test.ts
+++ b/scripts/public-beta-release.test.ts
@@ -6,6 +6,10 @@ import { publishedPackages, repositoryRoot } from "./packages.js";
 const npmVersion = "0.1.0-beta.2";
 const pythonVersion = "0.1.0b3";
 const goVersion = "0.1.0-beta.1";
+const publicationDate = "2026-09-01";
+const npmSourceCommit = "856cdcf354aa83a3acf8ee67043145adb9c99e09";
+const pythonSourceCommit = "663c526805746786f12b3be3e151e8ce06c80057";
+const goSourceCommit = "dbd5437362930f712157ffcc72c3296e971e4f5a";
 const betaLabel = "public beta";
 const compatibilityNotice = "There is no upgrade path between 0.x releases";
 
@@ -79,10 +83,19 @@ describe("the first public beta release", () => {
     }
   });
 
-  it("documents the beta versions in each changelog", async () => {
-    expect(await read("CHANGELOG.md")).toContain(`## ${npmVersion} — unreleased`);
-    expect(await read("python/CHANGELOG.md")).toContain(`## ${pythonVersion} — unreleased`);
-    expect(await read("go/CHANGELOG.md")).toContain(`## ${goVersion} — unreleased`);
+  it("dates and attributes the published beta versions in each changelog", async () => {
+    const entries = [
+      ["CHANGELOG.md", npmVersion, npmSourceCommit],
+      ["python/CHANGELOG.md", pythonVersion, pythonSourceCommit],
+      ["go/CHANGELOG.md", goVersion, goSourceCommit],
+    ] as const;
+
+    for (const [relativePath, version, sourceCommit] of entries) {
+      const changelog = await read(relativePath);
+      expect(changelog).toContain(`## ${version} — ${publicationDate}`);
+      expect(changelog).toContain(sourceCommit);
+      expect(changelog).not.toMatch(/^## .* — unreleased$/m);
+    }
   });
 
   it("builds the site with the supported Go toolchain line", async () => {
@@ -103,5 +116,14 @@ describe("the first public beta release", () => {
     expect(compatibility).toContain("Any failure stops the release train");
     expect(compatibility).toContain("A published version is never reused");
     expect(compatibility).toContain("Test registries are not part of the rehearsal");
+
+    const trainSection = compatibility.slice(
+      compatibility.indexOf("### First public beta release train"),
+      compatibility.indexOf("### npm packages"),
+    );
+    expect(trainSection).toContain("three source commits");
+    for (const sourceCommit of [pythonSourceCommit, npmSourceCommit, goSourceCommit]) {
+      expect(trainSection).toContain(sourceCommit);
+    }
   });
 });


### PR DESCRIPTION
Closes the changelog half of the 0.1.0 release train prep (Ontrack WH-568).

- `CHANGELOG.md`, `python/CHANGELOG.md`, `go/CHANGELOG.md`: the published entries carry their 2026-09-01 date in the existing `## version — date` style, and one sentence names the source commit and tag. No `— unreleased` heading remains for a version a registry serves.
- `docs/compatibility.md`: the "First public beta release train" section describes the train as it ran (three source commits, Python fix-forwards for missing attestations, the unpublished npm `beta.1` tag) rather than as intended.
- `scripts/public-beta-release.test.ts`: asserts the dates, the source commits, and the absence of `unreleased` headings; the train test checks the section names the three commits.

Verified locally: `pnpm format:check`, oxlint on `scripts`, `scripts/public-beta-release.test.ts`, `scripts/check-release.test.ts`, `readme-alignment:check`. Full `pnpm check` running.

https://claude.ai/code/session_019ndjYDJWkLZ2kATxFYxUhR
