### PR TITLE
[WH-570] Add a security policy naming the supported line

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ business write and its background job can commit in the same transaction, withou
 
 [Documentation](https://workhorse.run/docs) · [Quickstart](https://workhorse.run/docs/quickstart) ·
 [Live demo](https://demo.workhorse.run) · [Compatibility](docs/compatibility.md) ·
-[For AI agents](https://workhorse.run/llms.txt)
+[Security policy](SECURITY.md) · [For AI agents](https://workhorse.run/llms.txt)
 
 ## Why Workhorse
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security policy
+
+This policy states how to report a vulnerability in Workhorse privately, what to expect after a
+report, and which versions receive fixes. It is limited to what the project can honour today.
+
+## Report a vulnerability
+
+Report a vulnerability through
+[GitHub private vulnerability reporting](https://github.com/stablemates/workhorse/security/advisories/new).
+The report opens a private advisory that only the maintainers can read. Do not open a public
+Issue, a pull request, or a discussion for a suspected vulnerability.
+
+Include the affected package and version, the steps that reproduce the problem, and its impact.
+A proof of concept helps but is not required.
+
+The maintainers acknowledge a report within five business days. The acknowledgement names the
+maintainer who owns the report and the next step. Please give the maintainers time to ship a
+fix before disclosing the problem publicly. The maintainers agree a disclosure date with the
+reporter, and credit the reporter in the advisory unless the reporter asks otherwise.
+
+## Supported versions
+
+Workhorse is a public beta on the `0.x` line. Only the latest `0.x` minor release of each package
+line receives security fixes: the nine `@stablemates/workhorse*` npm packages, the
+`stablemates-workhorse` Python distribution, and the `github.com/stablemates/workhorse/go` module.
+An older minor does not receive a fix. Upgrade to the latest minor to receive one.
+[`docs/compatibility.md`](docs/compatibility.md) defines the supported runtimes and the release
+process.
+
+## How a fix ships
+
+A fix ships as a new, higher version. A published version is never re-tagged or replaced. When a
+release carries a security, secret, privacy, or legal exposure, the maintainers also deprecate the
+npm release, yank the PyPI release, or retract the Go version, and rotate or revoke any affected
+credential. Removal does not reverse prior access, so treat every published artifact as
+permanently observable. Each fix is recorded in the affected changelog and in a published GitHub
+security advisory.
+
+## Scope
+
+The policy covers the published packages and this repository's source. Reports about a
+deployment of Workhorse belong to the operator of that deployment, not to this project.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -217,6 +217,8 @@ A published version is never reused. An ordinary defect stays available and rece
 fix. A security, secret, privacy, or legal exposure triggers credential rotation and removal where
 the registry permits it. The response also deprecates the npm release, yanks the PyPI release, or
 retracts the Go version as appropriate. Removal does not make prior public access reversible.
+[`SECURITY.md`](../SECURITY.md) states how to report a vulnerability privately and which versions
+receive fixes.
 
 ### npm packages
 

--- a/scripts/public-beta-release.test.ts
+++ b/scripts/public-beta-release.test.ts
@@ -104,4 +104,20 @@ describe("the first public beta release", () => {
     expect(compatibility).toContain("A published version is never reused");
     expect(compatibility).toContain("Test registries are not part of the rehearsal");
   });
+
+  it("publishes a security policy that names the reporting channel and the supported line", async () => {
+    const policy = prose(await read("SECURITY.md"));
+    expect(policy).toContain("https://github.com/stablemates/workhorse/security/advisories/new");
+    expect(policy).toContain("acknowledge a report within five business days");
+    expect(policy).toContain(
+      "Only the latest `0.x` minor release of each package line receives security fixes",
+    );
+    expect(policy).toContain("A published version is never re-tagged or replaced");
+    expect(policy).toContain(
+      "deprecate the npm release, yank the PyPI release, or retract the Go version",
+    );
+
+    expect(await read("README.md")).toContain("[Security policy](SECURITY.md)");
+    expect(await read("docs/compatibility.md")).toContain("[`SECURITY.md`](../SECURITY.md)");
+  });
 });


### PR DESCRIPTION
Closes WH-570.

- Adds `SECURITY.md`: GitHub private vulnerability reporting as the channel, a five-business-day acknowledgement, the latest `0.x` minor of each package line as the only supported line, and the fix-forward, deprecate/yank/retract response from ADR 0045.
- The README links it in one clause and `docs/compatibility.md` links it once.
- `scripts/public-beta-release.test.ts` pins the reporting URL, the supported line, and both links.
- Private vulnerability reporting was enabled on the repository so the policy's link works.

https://claude.ai/code/session_01434SsUJvUc9hvQtNZLxqAG