### PR TITLE
[WH-563] Correct the parity line in docs/features.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ availability must be independent from the application database.
   compatibility facade. Its server and type contract are also published for package composition.
 - [`@stablemates/workhorse-otel`](typescript/otel) connects core's vendor-neutral telemetry to the
   host application's OpenTelemetry API providers.
-- The [Python SDK](python) and [Go SDK](go) implement the same PostgreSQL protocol.
+- The [Python SDK](python) and [Go SDK](go) implement the same PostgreSQL protocol and embed the
+  same operator dashboard.
 
 ## Learn and operate
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -12,8 +12,8 @@ This is the authoritative implementation snapshot for schema version 1. “Suppo
 | Deploy-synchronized worker-owned schedules                 |                                               | Arbitrary scheduled SQL                |
 | Persisted retry policies and terminal failure              | Success-path comparative baseline             | Workflow runtime                       |
 | Queue pause/resume/purge controls and OpenTelemetry        | Operations dashboard without SSO or RBAC      | Rust SDK                               |
-| Four ORM providers and framework-neutral dashboard host    | Python and Go SDKs, short of full parity      | Online production migration guarantees |
-|                                                            |                                               | Public HTTP ingress API                |
+| Four ORM providers and framework-neutral dashboard host    |                                               | Online production migration guarantees |
+| Python and Go SDKs at full parity with TypeScript          |                                               | Public HTTP ingress API                |
 | Live runtime plus immutable outcomes                       |                                               |                                        |
 | Append-only events and attempt history                     |                                               |                                        |
 | Immutable named checkpoint replay                          |                                               |                                        |


### PR DESCRIPTION
Closes the parity wording fix that WH-566 step 2 schedules for the 0.1.0 candidate.

- `docs/features.md` "At a glance" no longer lists Python and Go as partial; they now appear under Supported core as at full parity with TypeScript, which agrees with every per-language row in `docs/parity.md`.
- The README Packages entry states in one clause that both SDKs embed the same operator dashboard.
- `grep -rn 'short of full parity'` over `docs/`, `site/content/`, and the four READMEs returns nothing.

Checks run: `oxfmt --check`, `pnpm parity:check`, `pnpm readme-alignment:check`.

https://claude.ai/code/session_01EaNpxwShDW9ANo3iwNfhAP