### PR TITLE
[WH-586] Widen the timing margins in the flaky Python runtime tests

### DIFF
--- a/protocol/v1/runtime.json
+++ b/protocol/v1/runtime.json
@@ -42,7 +42,7 @@
     "followingJobType": "protocol.after-suspension",
     "checkpointName": "prepare",
     "waitName": "after-prepare",
-    "waitMs": 30,
+    "waitMs": 30000,
     "expectedHandlerOrder": ["suspension:1", "following:1", "suspension:1"],
     "expectedAfterSuspension": {
       "suspension": { "state": "scheduled", "attempt": 1 },

--- a/python/tests/test_worker.py
+++ b/python/tests/test_worker.py
@@ -1233,15 +1233,19 @@ def test_worker_renews_ownership_while_handler_runs(database_url: str) -> None:
         job_id = Queue(enqueue_connection).enqueue("lease.renewed", {})
         enqueue_connection.commit()
 
+        # The handler outlives the original lease, so only renewal keeps the completion
+        # accepted. The lease is ten heartbeats long: a loaded CI runner can stall the
+        # heartbeat thread or the database for several hundred milliseconds without the
+        # lease lapsing, which is what made the tighter 150 ms / 40 ms pairing flaky.
         def outlive_original_lease(_payload: object, _context: object) -> dict[str, bool]:
-            sleep(0.35)
+            sleep(1.5)
             return {"renewed": True}
 
         worker = Worker(
             worker_connection,
             worker_id="python-heartbeat-worker",
-            lease_ms=150,
-            heartbeat_ms=40,
+            lease_ms=1_000,
+            heartbeat_ms=100,
         ).handle("lease.renewed", outlive_original_lease)
 
         assert worker.run_once() is True

--- a/python/tests/test_worker_runtime_conformance.py
+++ b/python/tests/test_worker_runtime_conformance.py
@@ -216,7 +216,16 @@ def execute_suspension_replay_fixture(
     assert worker.run_once() is True
     assert_job_states(connection, job_ids, fixture["expectedAfterSlotRelease"])
 
-    sleep(max(0.11, fixture["waitMs"] / 1000 + 0.08))
+    # The wait is long enough that it cannot elapse between the suspension and the slot
+    # release check on a slow runner. Rewind it, as the Go fixture does, instead of
+    # sleeping through it, and promote it explicitly rather than waiting for the worker's
+    # maintenance interval.
+    connection.execute(
+        "UPDATE workhorse.job_runtime SET run_at = clock_timestamp() - interval '1 millisecond'"
+        " WHERE job_id = %s",
+        (job_ids["suspension"],),
+    )
+    connection.execute("SELECT * FROM workhorse.tick_v1(100, 100)").fetchall()
     assert worker.run_once() is True
     assert_job_states(connection, job_ids, fixture["expectedAfterReplay"])
     assert_attempt_count(connection, job_ids["suspension"], fixture["expectedAttemptsAfterReplay"])

--- a/typescript/core/test/sql-protocol-conformance.test.ts
+++ b/typescript/core/test/sql-protocol-conformance.test.ts
@@ -246,7 +246,15 @@ async function executeSuspensionReplayRuntimeFixture(
   await expect(worker.runOnce()).resolves.toBe(true);
   await expectJobStates(admin, ids, fixture.expectedAfterSlotRelease);
 
-  await sleep(Math.max(110, fixture.waitMs + 80));
+  // The wait is long enough that it cannot elapse between the suspension and the slot
+  // release check on a slow runner. Rewind it, as the Go fixture does, instead of
+  // sleeping through it, and promote it explicitly rather than waiting for the worker's
+  // maintenance interval.
+  await database.query(
+    "UPDATE workhorse.job_runtime SET run_at = clock_timestamp() - interval '1 millisecond' WHERE job_id = $1",
+    [ids.get("suspension")!],
+  );
+  await database.query("SELECT * FROM workhorse.tick_v1(100, 100)");
   await expect(worker.runOnce()).resolves.toBe(true);
   await expectJobStates(admin, ids, fixture.expectedAfterReplay);
   await expectAttemptCount(database, ids.get("suspension")!, fixture.expectedAttemptsAfterReplay);


### PR DESCRIPTION
Closes the two timing flakes named in WH-586 without weakening what either test asserts.

- `test_worker_renews_ownership_while_handler_runs`: lease 1000 ms, heartbeat 100 ms, handler 1.5 s. The handler still outlives the original lease; the test now survives heartbeat stalls up to about 900 ms instead of about 110 ms.
- `suspension-replay` shared fixture: `waitMs` 30 → 30000 so the wait cannot elapse before the slot-release check. The Python and TypeScript executors rewind `run_at` and run `tick_v1` before the replay, as the Go executor already did.

Verification: 20/20 consecutive runs of the renewal test at load average 12 with the full vitest suite running; Python, TypeScript, and Go fixture consumers pass; `format:check`, `lint`, `sql-catalogues:check`, `parity:check` clean.

https://claude.ai/code/session_01RhhuDJqwbMc44gchGG4mbU
