### PR TITLE
[WH-585] Anchor the deadline fixture's budget at the claim

### DIFF
--- a/go/worker_test.go
+++ b/go/worker_test.go
@@ -520,29 +520,6 @@ func (tracer heartbeatGateTracer) TraceQueryStart(
 
 func (heartbeatGateTracer) TraceQueryEnd(context.Context, *pgx.Conn, pgx.TraceQueryEndData) {}
 
-type claimGateTracer struct {
-	started chan struct{}
-	release <-chan struct{}
-	once    sync.Once
-}
-
-func (tracer *claimGateTracer) TraceQueryStart(
-	ctx context.Context,
-	_ *pgx.Conn,
-	data pgx.TraceQueryStartData,
-) context.Context {
-	if !strings.Contains(data.SQL, "claim_many_v1") {
-		return ctx
-	}
-	tracer.once.Do(func() {
-		close(tracer.started)
-		<-tracer.release
-	})
-	return ctx
-}
-
-func (*claimGateTracer) TraceQueryEnd(context.Context, *pgx.Conn, pgx.TraceQueryEndData) {}
-
 type notificationReconnectGateTracer struct {
 	mu               sync.Mutex
 	listenCalls      int
@@ -1396,21 +1373,34 @@ func executeWorkerCancellationFixture(t *testing.T, fixture workerRuntimeFixture
 	assertWorkerFixtureAttemptOutcomes(t, ctx, pool, jobID, []string{fixture.ExpectedAttemptOutcome})
 }
 
+// anchorDeadlineAtClaim starts a deadline fixture's budget inside the claim itself. claim_v1
+// filters ready jobs on job_runtime.deadline_at and returns job.deadline_at, so the trigger
+// rewrites both when the claim moves the row from ready to active. The worker then arms its local
+// timer durationMs after the claim's own clock, and no stall between the test and the claim can
+// spend the budget before the claim runs. The database is a throwaway conformance copy.
+func anchorDeadlineAtClaim(t *testing.T, ctx context.Context, pool *pgxpool.Pool, durationMS int) {
+	t.Helper()
+	if _, err := pool.Exec(ctx, fmt.Sprintf(`
+CREATE FUNCTION workhorse.test_anchor_deadline_at_claim() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF OLD.state = 'ready' AND NEW.state = 'active' THEN
+    NEW.deadline_at := clock_timestamp() + (%d * interval '1 millisecond');
+    UPDATE workhorse.job SET deadline_at = NEW.deadline_at WHERE id = NEW.job_id;
+  END IF;
+  RETURN NEW;
+END
+$$;
+CREATE TRIGGER test_anchor_deadline_at_claim BEFORE UPDATE ON workhorse.job_runtime
+  FOR EACH ROW EXECUTE FUNCTION workhorse.test_anchor_deadline_at_claim()`, durationMS)); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func executeWorkerExpirationFixture(t *testing.T, fixture workerRuntimeFixture) {
 	databaseURL := createConformanceDatabase(t, testDatabaseURL(t), "worker-"+fixture.Mode)
 	ctx := context.Background()
-	config, err := pgxpool.ParseConfig(databaseURL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var claimStarted chan struct{}
-	var releaseClaim chan struct{}
-	if fixture.Mode == "deadline" {
-		claimStarted = make(chan struct{})
-		releaseClaim = make(chan struct{})
-		config.ConnConfig.Tracer = &claimGateTracer{started: claimStarted, release: releaseClaim}
-	}
-	pool, err := pgxpool.NewWithConfig(ctx, config)
+	pool, err := pgxpool.New(ctx, databaseURL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1422,8 +1412,9 @@ func executeWorkerExpirationFixture(t *testing.T, fixture workerRuntimeFixture) 
 		RetryPolicy: map[string]any{"type": "fixed", "delayMs": 0},
 	}
 	if fixture.Mode == "deadline" {
-		deadline := time.Now().UTC().Add(30 * time.Second)
-		options.Deadline = &deadline
+		anchorDeadlineAtClaim(t, ctx, pool, fixture.DurationMS)
+		placeholder := time.Now().UTC().Add(time.Hour)
+		options.Deadline = &placeholder
 	} else {
 		options.ExecutionTimeoutMS = fixture.DurationMS
 	}
@@ -1469,24 +1460,6 @@ func executeWorkerExpirationFixture(t *testing.T, fixture workerRuntimeFixture) 
 				err       error
 			}{processed: processed, err: err}
 		}()
-		if fixture.Mode == "deadline" {
-			select {
-			case <-claimStarted:
-			case <-time.After(5 * time.Second):
-				close(releaseClaim)
-				t.Fatal("deadline worker did not reach its claim boundary")
-			}
-			if _, err := pool.Exec(
-				ctx,
-				"UPDATE workhorse.job_runtime SET deadline_at = clock_timestamp() + ($2 * interval '1 millisecond') WHERE job_id = $1::uuid",
-				jobID,
-				fixture.DurationMS,
-			); err != nil {
-				close(releaseClaim)
-				t.Fatal(err)
-			}
-			close(releaseClaim)
-		}
 		run := <-result
 		processed, err := run.processed, run.err
 		if err != nil || !processed {

--- a/python/tests/test_worker_runtime_conformance.py
+++ b/python/tests/test_worker_runtime_conformance.py
@@ -277,11 +277,13 @@ def execute_expiration_fixture(
     connection: psycopg.Connection[Any], fixture: Mapping[str, Any]
 ) -> None:
     queue_name = runtime_queue(fixture)
-    expiration = datetime.now(UTC) + timedelta(milliseconds=fixture["durationMs"])
+    # The deadline budget starts after the claim, inside early_claim. This value only has to be
+    # far enough away that the claim never skips the job.
+    placeholder = datetime.now(UTC) + timedelta(hours=1)
     options = (
         EnqueueOptions(
             queue=queue_name,
-            deadline=expiration,
+            deadline=placeholder,
             max_attempts=fixture["maxAttempts"],
             retry_policy={"type": "fixed", "delayMs": 0},
         )
@@ -317,8 +319,19 @@ def execute_expiration_fixture(
         rows = original_rows(statement, parameters)
         if statement is STATEMENTS.claim_many and rows:
             claimed = dict(rows[0])
-            field = "deadline_at" if fixture["mode"] == "deadline" else "attempt_timeout_at"
-            value = claimed[field]
+            if fixture["mode"] == "deadline":
+                field = "deadline_at"
+                anchored = connection.execute(
+                    "UPDATE workhorse.job_runtime "
+                    "SET deadline_at = clock_timestamp() + (%s * interval '1 millisecond') "
+                    "WHERE job_id = %s RETURNING deadline_at",
+                    (fixture["durationMs"], job_id),
+                ).fetchone()
+                assert anchored is not None
+                value = anchored[0]
+            else:
+                field = "attempt_timeout_at"
+                value = claimed[field]
             assert isinstance(value, datetime)
             claimed[field] = value - timedelta(milliseconds=fixture["localClockLeadMs"])
             return [claimed]


### PR DESCRIPTION
Closes WH-585 on Ontrack.

The shared `deadline-settles-after-early-local-timer` fixture failed under `-race` on a loaded runner with `processed=false err=<nil>`. The Go executor wrote the deadline before the claim ran, so the claim's own latency was charged against the 200 ms budget and `claim_v1` skipped the job as already expired. Python anchored the budget at enqueue and shared the fault. TypeScript writes the deadline after the claim returns and did not.

**Change**

- Go: a test-only `BEFORE UPDATE` trigger on `job_runtime` in the throwaway conformance database sets both `job_runtime.deadline_at` and `job.deadline_at` to `durationMs` after the claim's own clock when the row moves from ready to active. The claim gate tracer goes away. Because `claim_v1` returns `job.deadline_at`, the Go worker's early local timer is now actually armed; before, only the runtime row was rewritten and the fixture passed through the heartbeat path alone.
- Python: an hour-long placeholder at enqueue, then `early_claim` writes the database deadline after the claim returns and derives the local view from it, matching TypeScript.
- `durationMs` is unchanged.

**Evidence**

- Reproduced before the fix by stalling durationMs + 100 ms before the claim: Go fails every time and the skipped row reads `state=ready` with the deadline 107 ms past; Python fails the same way.
- With the same stall on top of the fix, both pass.
- `go test -race -count=20` over the three expiration fixtures with four CPU burners: pass in 42 s. Python conformance file: five consecutive passes. Both re-run after rebasing onto `main`.

https://claude.ai/code/session_01AeeMc5dNM3jNDBWvYwGzw1
