### PR TITLE
[WH-587] Apply the positioning line to the README, package READMEs, and site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # Workhorse
 
-Workhorse is a durable job queue built from PostgreSQL tables and versioned SQL functions. Your
-business write and its background job can commit in the same transaction, without another broker.
+A durable job queue for PostgreSQL, with TypeScript, Python, and Go workers on one SQL protocol.
 
-[![Build status](https://github.com/stablemates/workhorse/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/stablemates/workhorse/actions/workflows/ci.yml?query=branch%3Amain)
+Workhorse is versioned SQL functions inside the database you already run. Every language gets the
+same workers, the same durable waits, and the same dashboard, with no broker or server beside
+PostgreSQL.
 
 > **Public beta:** Workhorse is usable for evaluation and early production adoption, but 0.x minor
 > releases may break compatibility, including the schema. There is no upgrade path between 0.x
 > releases; ordered migrations begin at 1.0.0.
+
+[![Build status](https://github.com/stablemates/workhorse/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/stablemates/workhorse/actions/workflows/ci.yml?query=branch%3Amain)
 
 [Documentation](https://workhorse.run/docs) · [Quickstart](https://workhorse.run/docs/quickstart) ·
 [Live demo](https://demo.workhorse.run) · [Compatibility](docs/compatibility.md) ·

--- a/go/README.md
+++ b/go/README.md
@@ -1,7 +1,7 @@
 # `github.com/stablemates/workhorse/go`
 
-The Go client, worker runtime, and dashboard handler for the Workhorse PostgreSQL durable execution
-protocol.
+The Go client, worker runtime, and dashboard handler for the Workhorse durable job queue for
+PostgreSQL.
 
 > **Public beta:** Workhorse is usable for evaluation and early production adoption, but 0.x minor
 > releases may break compatibility, including the schema. There is no upgrade path between 0.x

--- a/go/doc.go
+++ b/go/doc.go
@@ -1,4 +1,4 @@
-// Package workhorse provides the public beta Go client and worker for the Workhorse PostgreSQL
-// durable execution protocol. During 0.x, minor releases may break compatibility and schema
-// upgrades require a fresh database.
+// Package workhorse provides the public beta Go client and worker for the Workhorse durable job
+// queue for PostgreSQL. During 0.x, minor releases may break compatibility and schema upgrades
+// require a fresh database.
 package workhorse

--- a/python/README.md
+++ b/python/README.md
@@ -1,7 +1,7 @@
 # `stablemates-workhorse`
 
-The Python clients, worker runtimes, and dashboard host for the Workhorse PostgreSQL durable
-execution protocol.
+The Python clients, worker runtimes, and dashboard host for the Workhorse durable job queue for
+PostgreSQL.
 
 > **Public beta:** Workhorse is usable for evaluation and early production adoption, but 0.x minor
 > releases may break compatibility, including the schema. There is no upgrade path between 0.x

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "stablemates-workhorse"
 version = "0.1.0b3"
-description = "Public beta Python SDK for the Workhorse PostgreSQL durable execution protocol"
+description = "Python SDK for the Workhorse durable job queue for PostgreSQL. Public beta."
 readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]

--- a/python/tests/test_release.py
+++ b/python/tests/test_release.py
@@ -53,7 +53,9 @@ def test_python_support_contract_matches_repository_declarations(database_url: s
     assert manifest["tool"]["ruff"]["target-version"] == (
         f"py{python_support['minimum'].replace('.', '')}"
     )
-    assert "Public beta Python SDK" in project["description"]
+    assert project["description"] == (
+        "Python SDK for the Workhorse durable job queue for PostgreSQL. Public beta."
+    )
     assert project["dependencies"] == [
         "jsonschema>=4.25,<5",
         "psycopg>=3.3,<4",

--- a/site/components/site-footer.tsx
+++ b/site/components/site-footer.tsx
@@ -40,8 +40,8 @@ export function SiteFooter() {
             <span className="text-[14px] font-semibold tracking-tight">Workhorse</span>
           </div>
           <p className="mt-3 max-w-xs text-[13px] leading-relaxed text-fd-muted-foreground">
-            A PostgreSQL-native durable execution protocol. Evidence-first, and explicit about what
-            it does not promise.
+            A durable job queue for PostgreSQL. Evidence-first, and explicit about what it does not
+            promise.
           </p>
         </div>
 

--- a/site/lib/site.ts
+++ b/site/lib/site.ts
@@ -2,8 +2,9 @@ const siteUrl = (import.meta.env?.VITE_SITE_URL ?? "https://workhorse.run").repl
 
 export const siteConfig = {
   name: "Workhorse",
-  tagline: "A PostgreSQL-native durable execution protocol",
-  description: "A durable job queue built on PostgreSQL.",
+  tagline: "A durable job queue for PostgreSQL",
+  description:
+    "A durable job queue for PostgreSQL, with TypeScript, Python, and Go workers on one SQL protocol.",
   url: siteUrl,
   socialImage: `${siteUrl}/brand/workhorse-mark.png`,
   github: "https://github.com/stablemates/workhorse",

--- a/site/src/routes/index.tsx
+++ b/site/src/routes/index.tsx
@@ -573,8 +573,9 @@ function Hero() {
             <span className="wh-accent-text">Harness</span> the Postgres you already run.
           </h1>
           <p className="mt-6 max-w-xl text-pretty text-lg leading-relaxed text-fd-muted-foreground">
-            Durable background tasks with crash recovery, efficient long waits, and fleet-wide
-            concurrency controls.
+            Workhorse is versioned SQL functions inside the database you already run. Every language
+            gets the same workers, the same durable waits, and the same dashboard, with no broker or
+            server beside PostgreSQL.
           </p>
           <div className="mt-8">
             <HeroActions />

--- a/typescript/core/README.md
+++ b/typescript/core/README.md
@@ -1,7 +1,7 @@
 # `@stablemates/workhorse`
 
-The TypeScript client, worker runtime, schema tools, and operator API for the Workhorse PostgreSQL
-durable execution protocol.
+The TypeScript client, worker runtime, schema tools, and operator API for the Workhorse durable job
+queue for PostgreSQL.
 
 > **Public beta:** Workhorse is usable for evaluation and early production adoption, but 0.x minor
 > releases may break compatibility, including the schema. There is no upgrade path between 0.x

--- a/typescript/core/package.json
+++ b/typescript/core/package.json
@@ -2,7 +2,7 @@
   "name": "@stablemates/workhorse",
   "version": "0.1.0-beta.2",
   "private": false,
-  "description": "Public beta PostgreSQL durable job queue and execution protocol",
+  "description": "A durable job queue for PostgreSQL. Public beta.",
   "homepage": "https://workhorse.run",
   "bugs": {
     "url": "https://github.com/stablemates/workhorse/issues"


### PR DESCRIPTION
Execution Issue of the marketing map for ADR 0051 (`docs/decisions/0051-lead-with-durable-job-queue.md`).

- `README.md` opens with the line verbatim, then the protocol clause, then the Public beta blockquote as ADR 0042 words it. The build badge moves below the blockquote.
- `typescript/core/README.md`, `python/README.md`, `go/README.md`, and `go/doc.go` name their role in "the Workhorse durable job queue for PostgreSQL".
- `site/lib/site.ts`: `tagline` is the short form, `description` is the full line. `site/components/site-footer.tsx` takes the short form. The hero paragraph in `site/src/routes/index.tsx` carries the protocol clause; the h1 stays.
- `typescript/core/package.json` and `python/pyproject.toml` descriptions carry the short form with the Public beta label after the line, because ADR 0051 keeps the label outside the line and `scripts/public-beta-release.test.ts` requires the label in every registry description.

The GitHub repository description is set after this merges, in the same task.

Verified: `pnpm readme-alignment:check`, `pnpm format:check`, `pnpm docs:typecheck`, `scripts/public-beta-release.test.ts`, and `go vet ./...` pass. The acceptance grep matches only lines inside `docs/decisions` (GNU grep's `--exclude-dir` matches directory base names, so `docs/decisions` does not exclude them) and the ignored Python venv metadata.

https://claude.ai/code/session_01ExfuxKrLJmM2cAwc84crme