### PR TITLE
[WH-589] Ship the site blog section: collection, routes, twins, and feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ scripts/with-env-probe.tmp.*
 /site/public/llms-full.txt
 /site/public/docs.md
 /site/public/docs/
+/site/public/blog/
 /sql/schema.sql

--- a/site/README.md
+++ b/site/README.md
@@ -1,9 +1,10 @@
 # @stablemates/workhorse-site
 
-The documentation site: a TanStack Start app serving the landing page at `/`
-and the Fumadocs-rendered product documentation under `/docs`. Content rules
-for the documentation itself live in the repository root `CLAUDE.md`; this
-file records conventions of the site's own UI.
+The documentation site: a TanStack Start app serving the landing page at `/`,
+the Fumadocs-rendered product documentation under `/docs`, and long-form posts
+under `/blog`. Content rules for the documentation itself live in the
+repository root `CLAUDE.md`; this file records conventions of the site's own
+UI and of the blog.
 
 ## Wide-viewport density: viewport-gated zoom
 
@@ -58,6 +59,40 @@ different set than the others.
   exercises the package on every change, so the entry carries no date.
   `documented` means a person checked it, so the entry must carry `verifiedOn`.
 - `typescript/core/test/site-integrations-catalog.test.ts` enforces all of it.
+
+## The blog
+
+`content/blog/` is the home for long-form content (ADR 0052). A post is one
+MDX file, `content/blog/<slug>.mdx`, served at `/blog/<slug>` with that URL
+as its canonical. The slug is lowercase letters, digits, and single hyphens.
+The frontmatter is exactly these three keys:
+
+```yaml
+---
+title: The post title
+description: One sentence a reader sees on the index, in the feed, and in search results.
+date: 2026-09-07
+---
+```
+
+- `date` is an ISO calendar date, `YYYY-MM-DD`. It orders the index and the
+  feed, newest first, and prints on the page. There is no author field.
+- `scripts/gen-docs-index.ts` reads the collection at build time through
+  `scripts/blog-posts.ts` and fails the build on a missing or malformed field.
+  It adds `/blog` and every post to the prerender list and `sitemap.xml`,
+  writes a Markdown twin per post at `/blog/<slug>.md`, and writes the RSS
+  feed at `/blog/feed.xml`. `llms.txt` and `llms-full.txt` never list a post.
+- With zero posts the "Blog" link is absent from the header and the footer,
+  and `/blog` is absent from the sitemap and the prerender list, so the
+  section can live on `main` before the first post without an empty page
+  reaching a reader.
+- A post's code is not compiled by `scripts/check-language-examples.ts`. A
+  post either reuses a snippet from `lib/landing-snippets.ts` or verifies its
+  example against the source by hand, as the writing rules in the repository
+  root `CLAUDE.md` already require.
+- The Markdown twin transform knows `Tabs` and `Tab` and no other component.
+  A post that uses another MDX component fails the build until
+  `scripts/mdx-to-markdown.ts` learns to expand it.
 
 ## Other landing conventions
 

--- a/site/app/layout.config.tsx
+++ b/site/app/layout.config.tsx
@@ -1,11 +1,12 @@
 import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
 import { WorkhorseWordmark } from "@/components/logo";
+import { hasPosts } from "@/lib/blog";
 import { demoUrl, siteConfig } from "@/lib/site";
 
 /**
  * The header carries the wordmark, the main documentation destinations, the
- * GitHub link, and one external link to the hosted demo. Sidebar groups own
- * every deeper destination.
+ * blog once it has a post, the GitHub link, and one external link to the
+ * hosted demo. Sidebar groups own every deeper destination.
  */
 export const baseOptions: BaseLayoutProps = {
   nav: {
@@ -18,6 +19,7 @@ export const baseOptions: BaseLayoutProps = {
     { text: "Quickstart", url: "/docs/quickstart" },
     { text: "Examples", url: "/docs/examples" },
     { text: "API", url: "/docs/api" },
+    ...(hasPosts ? [{ text: "Blog", url: "/blog" }] : []),
     { text: "Demo", url: demoUrl, external: true },
   ],
 };

--- a/site/components/site-footer.tsx
+++ b/site/components/site-footer.tsx
@@ -1,4 +1,5 @@
 import { WorkhorseMark } from "@/components/logo";
+import { hasPosts } from "@/lib/blog";
 import { demoUrl, siteConfig } from "@/lib/site";
 
 const columns = [
@@ -23,6 +24,9 @@ const columns = [
   {
     label: "Project",
     links: [
+      // The blog is linked only once it has a post, so an empty index never
+      // reaches a reader (ADR 0052).
+      ...(hasPosts ? [{ href: "/blog", text: "Blog" }] : []),
       { href: siteConfig.github, text: "GitHub", external: true },
       { href: siteConfig.npm, text: "npm", external: true },
       { href: demoUrl, text: "Hosted demo", external: true },

--- a/site/lib/blog.ts
+++ b/site/lib/blog.ts
@@ -1,0 +1,53 @@
+import blogIndex from "@/.source/blog-index.json";
+
+/**
+ * The blog collection as the routes and the navigation see it (ADR 0052).
+ *
+ * `scripts/gen-docs-index.ts` writes `.source/blog-index.json` at build time
+ * with every post newest first. Reading that JSON here, rather than the
+ * Fumadocs loader, keeps `node:fs` out of the browser bundle, for the same
+ * reason the docs sidebar is generated rather than loaded.
+ */
+export interface PostRecord {
+  readonly slug: string;
+  readonly url: string;
+  readonly path: string;
+  readonly title: string;
+  readonly description: string;
+  /** ISO calendar date, `YYYY-MM-DD`. */
+  readonly date: string;
+}
+
+/** Every post, newest first. */
+export const posts: readonly PostRecord[] = blogIndex.posts as PostRecord[];
+
+/**
+ * Whether the section is linked at all. With zero posts the "Blog" link is
+ * absent from the header and the footer, so an empty index never reaches a
+ * reader.
+ */
+export const hasPosts = posts.length > 0;
+
+const months = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const;
+
+/**
+ * `2026-09-07` as `September 7, 2026`. Formatted by hand so the server and the
+ * browser agree on the text without depending on either one's locale data.
+ */
+export function formatPostDate(date: string): string {
+  const [year, month, day] = date.split("-").map(Number);
+  return `${months[(month ?? 1) - 1]} ${day}, ${year}`;
+}

--- a/site/lib/mdx-loader.tsx
+++ b/site/lib/mdx-loader.tsx
@@ -1,6 +1,7 @@
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/page";
 
 import browserCollections from "@/.source/browser";
+import { formatPostDate } from "@/lib/blog";
 import { getMDXComponents } from "@/mdx-components";
 
 /**
@@ -34,6 +35,34 @@ export const clientLoader = browserCollections.docs.createClientLoader<Record<st
           <MDX components={getMDXComponents()} />
         </DocsBody>
       </DocsPage>
+    );
+  },
+});
+
+/**
+ * Renders one blog post from the browser collection. The post's date is not in
+ * the compiled frontmatter, because the default page schema keeps only the
+ * title and description, so the route passes it in from the generated index.
+ */
+export const postLoader = browserCollections.blog.createClientLoader<{ readonly date: string }>({
+  id: "blog",
+  component: (loaded, { date }) => {
+    const MDX = loaded.default;
+    const { title, description } = loaded.frontmatter;
+
+    return (
+      <article className="mx-auto w-full max-w-3xl px-5 py-12 lg:px-8">
+        <header>
+          <time dateTime={date} className="wh-mono-label">
+            {formatPostDate(date)}
+          </time>
+          <h1 className="wh-docs-title mt-3 text-3xl font-semibold sm:text-4xl">{title}</h1>
+          <p className="wh-docs-description mt-4 text-lg text-fd-muted-foreground">{description}</p>
+        </header>
+        <div className="prose wh-docs-body">
+          <MDX components={getMDXComponents()} />
+        </div>
+      </article>
     );
   },
 });

--- a/site/lib/seo.ts
+++ b/site/lib/seo.ts
@@ -1,14 +1,28 @@
 import { siteConfig } from "./site";
 
-interface DocumentationPageMetadata {
+interface PageMetadata {
   readonly url: string;
   readonly title: string;
   readonly description: string;
 }
 
-export function documentationHead(page: DocumentationPageMetadata) {
+interface ArticleOptions {
+  /** The schema.org type of the JSON-LD record. */
+  readonly schemaType: "TechArticle" | "BlogPosting";
+  /** ISO calendar date, for a post's `article:published_time` and `datePublished`. */
+  readonly published?: string;
+}
+
+/**
+ * The head of one article page: canonical link, description, Open Graph tags
+ * with `og:type` `article`, the `text/markdown` alternate that names the
+ * page's twin, and a JSON-LD record. Documentation pages and blog posts share
+ * it and differ only in the schema.org type and whether they carry a date.
+ */
+function articleHead(page: PageMetadata, options: ArticleOptions) {
   const canonical = `${siteConfig.url}${page.url}`;
   const title = `${page.title} — ${siteConfig.name}`;
+  const published = options.published ? `${options.published}T00:00:00Z` : undefined;
 
   return {
     meta: [
@@ -18,6 +32,7 @@ export function documentationHead(page: DocumentationPageMetadata) {
       { property: "og:url", content: canonical },
       { property: "og:title", content: page.title },
       { property: "og:description", content: page.description },
+      ...(published ? [{ property: "article:published_time", content: published }] : []),
       { name: "twitter:title", content: title },
       { name: "twitter:description", content: page.description },
     ],
@@ -30,11 +45,12 @@ export function documentationHead(page: DocumentationPageMetadata) {
         type: "application/ld+json",
         children: JSON.stringify({
           "@context": "https://schema.org",
-          "@type": "TechArticle",
+          "@type": options.schemaType,
           headline: page.title,
           description: page.description,
           url: canonical,
           image: siteConfig.socialImage,
+          ...(published ? { datePublished: published } : {}),
           isPartOf: {
             "@type": "WebSite",
             name: siteConfig.name,
@@ -42,6 +58,37 @@ export function documentationHead(page: DocumentationPageMetadata) {
           },
         }),
       },
+    ],
+  };
+}
+
+export function documentationHead(page: PageMetadata) {
+  return articleHead(page, { schemaType: "TechArticle" });
+}
+
+export function postHead(post: PageMetadata & { readonly date: string }) {
+  return articleHead(post, { schemaType: "BlogPosting", published: post.date });
+}
+
+/** The head of `/blog`: its canonical link, description, and the feed. */
+export function blogIndexHead() {
+  const canonical = `${siteConfig.url}/blog`;
+  const title = `Blog — ${siteConfig.name}`;
+  const description = `Long-form writing about ${siteConfig.name}, ${siteConfig.description.replace(/^A /, "a ").replace(/\.$/, "")}.`;
+
+  return {
+    meta: [
+      { title },
+      { name: "description", content: description },
+      { property: "og:url", content: canonical },
+      { property: "og:title", content: title },
+      { property: "og:description", content: description },
+      { name: "twitter:title", content: title },
+      { name: "twitter:description", content: description },
+    ],
+    links: [
+      { rel: "canonical", href: canonical },
+      { rel: "alternate", type: "application/rss+xml", href: `${canonical}/feed.xml` },
     ],
   };
 }

--- a/site/scripts/blog-posts.test.ts
+++ b/site/scripts/blog-posts.test.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadPosts, renderFeed } from "./blog-posts.js";
+
+const directories: string[] = [];
+
+async function collection(files: Readonly<Record<string, string>>): Promise<URL> {
+  const dir = await mkdtemp(join(tmpdir(), "workhorse-blog-"));
+  directories.push(dir);
+  await Promise.all(
+    Object.entries(files).map(([name, source]) => writeFile(join(dir, name), source)),
+  );
+  return pathToFileURL(`${dir}/`);
+}
+
+const post = (title: string, date: string, body = "Body.\n"): string =>
+  `---\ntitle: ${title}\ndescription: About ${title}.\ndate: ${date}\n---\n\n${body}`;
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("the blog collection", () => {
+  it("reads every post newest first, with the frontmatter and the body", async () => {
+    const dir = await collection({
+      "older.mdx": post("Older", "2026-09-01"),
+      "newer.mdx": post("Newer", "2026-09-07", "## Heading\n\nText.\n"),
+      ".gitkeep": "",
+      "notes.txt": "not a post",
+    });
+
+    const posts = await loadPosts(dir);
+
+    expect(posts.map((entry) => entry.slug)).toEqual(["newer", "older"]);
+    expect(posts[0]).toMatchObject({
+      url: "/blog/newer",
+      path: "newer.mdx",
+      title: "Newer",
+      description: "About Newer.",
+      date: "2026-09-07",
+      body: "## Heading\n\nText.\n",
+    });
+  });
+
+  it("orders two posts on the same day by slug", async () => {
+    const dir = await collection({
+      "b-post.mdx": post("B", "2026-09-07"),
+      "a-post.mdx": post("A", "2026-09-07"),
+    });
+
+    expect((await loadPosts(dir)).map((entry) => entry.slug)).toEqual(["a-post", "b-post"]);
+  });
+
+  it("is empty when the directory is empty or missing", async () => {
+    const dir = await collection({ ".gitkeep": "" });
+    expect(await loadPosts(dir)).toEqual([]);
+    expect(await loadPosts(new URL("missing/", dir))).toEqual([]);
+  });
+
+  it("fails the build on a missing or malformed field", async () => {
+    await expect(
+      loadPosts(await collection({ "hello.mdx": post("Hello", "2026-9-7") })),
+    ).rejects.toThrow('The post "hello" needs a frontmatter date as an ISO calendar date');
+    await expect(
+      loadPosts(await collection({ "hello.mdx": post("Hello", "2026-02-30") })),
+    ).rejects.toThrow("ISO calendar date");
+    await expect(
+      loadPosts(await collection({ "hello.mdx": "---\ntitle: Hello\ndate: 2026-09-07\n---\n" })),
+    ).rejects.toThrow('The post "hello" is missing a frontmatter description');
+    await expect(
+      loadPosts(await collection({ "Hello World.mdx": post("Hello", "2026-09-07") })),
+    ).rejects.toThrow("is not a URL slug");
+  });
+});
+
+describe("the feed", () => {
+  it("is RSS 2.0 with one item per post, newest first, at its canonical URL", async () => {
+    const dir = await collection({
+      "older.mdx": post("Older & wiser", "2026-09-01"),
+      "newer.mdx": post("Newer <post>", "2026-09-07"),
+    });
+    const feed = renderFeed(
+      { title: "Workhorse blog", description: "Posts.", base: "https://workhorse.run" },
+      await loadPosts(dir),
+    );
+
+    expect(feed.startsWith('<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0"')).toBe(
+      true,
+    );
+    expect(feed).toContain("<link>https://workhorse.run/blog</link>");
+    expect(feed).toContain(
+      '<atom:link href="https://workhorse.run/blog/feed.xml" rel="self" type="application/rss+xml" />',
+    );
+    const links = [...feed.matchAll(/<item>[\s\S]*?<link>([^<]+)<\/link>/g)].map((m) => m[1]);
+    expect(links).toEqual(["https://workhorse.run/blog/newer", "https://workhorse.run/blog/older"]);
+    expect(feed).toContain("<title>Newer &lt;post&gt;</title>");
+    expect(feed).toContain("<title>Older &amp; wiser</title>");
+    expect(feed).toContain("<pubDate>Mon, 07 Sep 2026 00:00:00 GMT</pubDate>");
+    expect(feed).toContain('<guid isPermaLink="true">https://workhorse.run/blog/newer</guid>');
+  });
+});

--- a/site/scripts/blog-posts.ts
+++ b/site/scripts/blog-posts.ts
@@ -1,0 +1,135 @@
+import { readFile, readdir } from "node:fs/promises";
+
+import { frontmatterValue, stripFrontmatter } from "./frontmatter.js";
+
+/**
+ * The blog collection as the build sees it (ADR 0052).
+ *
+ * A post is one MDX file under `content/blog/` with frontmatter `title`,
+ * `description`, and `date`. This module reads that directory into records the
+ * generator writes out, and renders the RSS feed, so `gen-docs-index.ts` stays
+ * the one script that decides what the site ships and this file stays the one
+ * place that knows what a post is.
+ */
+
+export interface PostRecord {
+  readonly slug: string;
+  /** Site-relative URL, `/blog/<slug>`. */
+  readonly url: string;
+  /** Path of the MDX file inside the collection, for the client loader. */
+  readonly path: string;
+  readonly title: string;
+  readonly description: string;
+  /** ISO calendar date, `YYYY-MM-DD`. */
+  readonly date: string;
+  /** The post body with its frontmatter removed, for the Markdown twin. */
+  readonly body: string;
+}
+
+const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * A calendar date is valid when it has the ISO shape and names a day that
+ * exists. `new Date("2026-02-30")` rolls over to March, so the check is that
+ * the parsed date prints back as the string it was parsed from.
+ */
+function isCalendarDate(value: string): boolean {
+  if (!datePattern.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().startsWith(value);
+}
+
+/**
+ * Reads every post in `contentDir`, newest first. Two posts on the same day
+ * sort by slug so the order is the same on every build. A post with a missing
+ * or malformed field fails the build, because the index, the feed, and the
+ * twin all print the field and a blank in any of them reaches a reader.
+ */
+export async function loadPosts(contentDir: URL): Promise<PostRecord[]> {
+  const entries = await readdir(contentDir, { withFileTypes: true }).catch(
+    (error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return [];
+      throw error;
+    },
+  );
+  const slugs = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".mdx"))
+    .map((entry) => entry.name.replace(/\.mdx$/, ""));
+
+  const posts = await Promise.all(
+    slugs.map(async (slug): Promise<PostRecord> => {
+      if (!slugPattern.test(slug)) {
+        throw new Error(
+          `The post file "${slug}.mdx" is not a URL slug. ` +
+            "Use lowercase letters, digits, and single hyphens.",
+        );
+      }
+      const source = await readFile(new URL(`${slug}.mdx`, contentDir), "utf8");
+      const title = frontmatterValue(source, "title");
+      const description = frontmatterValue(source, "description");
+      const date = frontmatterValue(source, "date");
+      if (!title) throw new Error(`The post "${slug}" is missing a frontmatter title`);
+      if (!description) throw new Error(`The post "${slug}" is missing a frontmatter description`);
+      if (!date || !isCalendarDate(date)) {
+        throw new Error(
+          `The post "${slug}" needs a frontmatter date as an ISO calendar date (YYYY-MM-DD)`,
+        );
+      }
+      const body = stripFrontmatter(source);
+      return { slug, url: `/blog/${slug}`, path: `${slug}.mdx`, title, description, date, body };
+    }),
+  );
+
+  return posts.toSorted((a, b) => b.date.localeCompare(a.date) || a.slug.localeCompare(b.slug));
+}
+
+const escapeXml = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+
+/** RFC 822 form of a calendar date at midnight UTC, as `<pubDate>` requires. */
+const rfc822 = (date: string): string => new Date(`${date}T00:00:00Z`).toUTCString();
+
+interface FeedChannel {
+  readonly title: string;
+  readonly description: string;
+  /** Site origin without a trailing slash, `https://workhorse.run`. */
+  readonly base: string;
+}
+
+/**
+ * The RSS 2.0 feed at `/blog/feed.xml`. Every `<link>` and `<guid>` is the
+ * post's canonical URL, so a reader that follows an item lands on the site and
+ * never on a syndicated copy. `posts` arrive newest first from `loadPosts`, and
+ * the feed keeps that order.
+ */
+export function renderFeed(channel: FeedChannel, posts: readonly PostRecord[]): string {
+  const items = posts.map((post) => {
+    const link = `${channel.base}${post.url}`;
+    return [
+      "    <item>",
+      `      <title>${escapeXml(post.title)}</title>`,
+      `      <link>${link}</link>`,
+      `      <guid isPermaLink="true">${link}</guid>`,
+      `      <pubDate>${rfc822(post.date)}</pubDate>`,
+      `      <description>${escapeXml(post.description)}</description>`,
+      "    </item>",
+    ].join("\n");
+  });
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(channel.title)}</title>
+    <link>${channel.base}/blog</link>
+    <description>${escapeXml(channel.description)}</description>
+    <language>en</language>
+    <atom:link href="${channel.base}/blog/feed.xml" rel="self" type="application/rss+xml" />
+${items.join("\n")}
+  </channel>
+</rss>
+`;
+}

--- a/site/scripts/frontmatter.ts
+++ b/site/scripts/frontmatter.ts
@@ -1,0 +1,21 @@
+/**
+ * Reads MDX frontmatter without a YAML parser. A page's frontmatter is flat
+ * `key: value` lines, and the build needs only the few keys it prints, so a
+ * line match is enough and keeps the generator free of a parser dependency.
+ */
+
+const block = /^---\r?\n([\s\S]*?)\r?\n---/;
+
+/** The value of `key` in the frontmatter of `source`, with quotes removed. */
+export function frontmatterValue(source: string, key: string): string | undefined {
+  const match = block.exec(source);
+  if (!match?.[1]) return undefined;
+  const line = new RegExp(`^${key}:\\s*(.+)$`, "m").exec(match[1]);
+  if (!line?.[1]) return undefined;
+  return line[1].trim().replace(/^["']|["']$/g, "");
+}
+
+/** The body of `source` with its frontmatter removed and leading blank lines dropped. */
+export function stripFrontmatter(source: string): string {
+  return source.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, "").trimStart();
+}

--- a/site/scripts/gen-docs-index.ts
+++ b/site/scripts/gen-docs-index.ts
@@ -1,7 +1,9 @@
-import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 
 import { type Integration, type IntegrationCategory, isPublished } from "../lib/integrations.js";
 import { siteConfig } from "../lib/site.js";
+import { loadPosts, renderFeed } from "./blog-posts.js";
+import { frontmatterValue, stripFrontmatter } from "./frontmatter.js";
 import { mdxToMarkdown } from "./mdx-to-markdown.js";
 
 /**
@@ -285,14 +287,6 @@ if (!structure.some((group) => group.title === catalogGroup)) {
   throw new Error(`meta.json has no ---${catalogGroup}--- separator for the catalog to fill`);
 }
 
-const frontmatterValue = (source: string, key: string): string | undefined => {
-  const block = /^---\r?\n([\s\S]*?)\r?\n---/.exec(source);
-  if (!block?.[1]) return undefined;
-  const line = new RegExp(`^${key}:\\s*(.+)$`, "m").exec(block[1]);
-  if (!line?.[1]) return undefined;
-  return line[1].trim().replace(/^["']|["']$/g, "");
-};
-
 const entries = await readdir(contentDir, { withFileTypes: true });
 const slugs = entries
   .filter((entry) => entry.isFile() && entry.name.endsWith(".mdx"))
@@ -339,10 +333,10 @@ await Promise.all(
 
     // The catalog tag becomes Markdown before the tab transform runs, so the
     // transform never meets a component the sidebar generator owns.
-    const body = source
-      .replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, "")
-      .trimStart()
-      .replace(/^<IntegrationCatalog \/>$/m, () => catalogMarkdown);
+    const body = stripFrontmatter(source).replace(
+      /^<IntegrationCatalog \/>$/m,
+      () => catalogMarkdown,
+    );
     if (body.includes("<IntegrationCatalog")) {
       throw new Error(`The Markdown twin for "${slug}" still contains the catalog tag`);
     }
@@ -416,6 +410,20 @@ await writeFile(
   )}\n`,
 );
 
+/**
+ * The blog (ADR 0052). Posts are not documentation: they join the prerender
+ * list and the sitemap, and each gets a twin, but `llms.txt` and
+ * `llms-full.txt` never list one. With zero posts the section has no routes at
+ * all, so nothing links `/blog` and no empty page reaches a reader.
+ */
+const posts = await loadPosts(new URL("../content/blog/", import.meta.url));
+const blogRoutes = posts.length > 0 ? ["/blog", ...posts.map((post) => post.url)] : [];
+
+await writeFile(
+  new URL("blog-index.json", outDir),
+  `${JSON.stringify({ posts: posts.map(({ body: _body, ...post }) => post) }, null, 2)}\n`,
+);
+
 const routes = [
   "/",
   "/docs",
@@ -423,6 +431,7 @@ const routes = [
     .map((page) => page.url)
     .filter((url) => url !== "/docs")
     .toSorted(),
+  ...blogRoutes,
 ];
 
 await writeFile(
@@ -480,6 +489,39 @@ await Promise.all(
     await writeFile(new URL(target, import.meta.url), `${frontmatter}\n${document}`);
   }),
 );
+
+/**
+ * Post twins at `/blog/<slug>.md` and the feed at `/blog/feed.xml`. The
+ * directory is rebuilt from scratch, because `public/` ships as it stands and a
+ * twin left over from a post that no longer exists would keep being served.
+ */
+const blogDir = new URL("../public/blog/", import.meta.url);
+await rm(blogDir, { recursive: true, force: true });
+if (posts.length > 0) {
+  await mkdir(blogDir, { recursive: true });
+  await Promise.all(
+    posts.map(async (post) => {
+      const frontmatter = [
+        "---",
+        `title: ${JSON.stringify(post.title)}`,
+        `description: ${JSON.stringify(post.description)}`,
+        `canonical: ${JSON.stringify(`${base}${post.url}`)}`,
+        `date: ${JSON.stringify(post.date)}`,
+        "---",
+        "",
+      ].join("\n");
+      const document = `# ${post.title}\n\n> ${post.description}\n\n${mdxToMarkdown(post.body, `blog/${post.slug}`)}`;
+      await writeFile(new URL(`${post.slug}.md`, blogDir), `${frontmatter}\n${document}`);
+    }),
+  );
+  await writeFile(
+    new URL("feed.xml", blogDir),
+    renderFeed(
+      { title: `${siteConfig.name} blog`, description: siteConfig.description, base },
+      posts,
+    ),
+  );
+}
 
 /**
  * The page an agent starts at, and the page whose install commands it copies.
@@ -600,4 +642,6 @@ Sitemap: ${base}/sitemap.xml
 `,
 );
 
-console.log(`Wrote the sidebar tree and metadata for ${pages.size} pages`);
+console.log(
+  `Wrote the sidebar tree and metadata for ${pages.size} pages and ${posts.length} posts`,
+);

--- a/site/source.config.ts
+++ b/site/source.config.ts
@@ -1,7 +1,22 @@
-import { defineConfig, defineDocs } from "fumadocs-mdx/config";
+import { pageSchema } from "fumadocs-core/source/schema";
+import { defineCollections, defineConfig, defineDocs } from "fumadocs-mdx/config";
 
 export const docs = defineDocs({
   dir: "content/docs",
+});
+
+/**
+ * Long-form posts, one MDX file per post at `content/blog/<slug>.mdx`, served
+ * at `/blog/<slug>` (ADR 0052). The frontmatter is `title`, `description`, and
+ * `date`. The page schema types the first two for the compiled module and drops
+ * the rest; `scripts/gen-docs-index.ts` reads and validates all three at build
+ * time and hands the date to the route. There is no author field: the posting
+ * identity is decided elsewhere and can add one.
+ */
+export const blog = defineCollections({
+  type: "doc",
+  dir: "content/blog",
+  schema: pageSchema,
 });
 
 export default defineConfig({

--- a/site/src/routeTree.gen.ts
+++ b/site/src/routeTree.gen.ts
@@ -10,14 +10,22 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as BlogRouteImport } from './routes/blog'
 import { Route as DocsRouteImport } from './routes/docs'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
+import { Route as BlogIndexRouteImport } from './routes/blog/index'
+import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 import { Route as DocsIndexRouteImport } from './routes/docs/index'
 import { Route as DocsSplatRouteImport } from './routes/docs/$'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BlogRoute = BlogRouteImport.update({
+  id: '/blog',
+  path: '/blog',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DocsRoute = DocsRouteImport.update({
@@ -29,6 +37,16 @@ const ApiSearchRoute = ApiSearchRouteImport.update({
   id: '/api/search',
   path: '/api/search',
   getParentRoute: () => rootRouteImport,
+} as any)
+const BlogIndexRoute = BlogIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => BlogRoute,
+} as any)
+const BlogSlugRoute = BlogSlugRouteImport.update({
+  id: '/$slug',
+  path: '/$slug',
+  getParentRoute: () => BlogRoute,
 } as any)
 const DocsIndexRoute = DocsIndexRouteImport.update({
   id: '/',
@@ -43,35 +61,61 @@ const DocsSplatRoute = DocsSplatRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/blog': typeof BlogRouteWithChildren
   '/docs': typeof DocsRouteWithChildren
   '/api/search': typeof ApiSearchRoute
+  '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
+  '/blog/': typeof BlogIndexRoute
   '/docs/': typeof DocsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/api/search': typeof ApiSearchRoute
+  '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
+  '/blog': typeof BlogIndexRoute
   '/docs': typeof DocsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/blog': typeof BlogRouteWithChildren
   '/docs': typeof DocsRouteWithChildren
   '/api/search': typeof ApiSearchRoute
+  '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
+  '/blog/': typeof BlogIndexRoute
   '/docs/': typeof DocsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/docs' | '/api/search' | '/docs/$' | '/docs/'
+  fullPaths:
+    | '/'
+    | '/blog'
+    | '/docs'
+    | '/api/search'
+    | '/blog/$slug'
+    | '/docs/$'
+    | '/blog/'
+    | '/docs/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/api/search' | '/docs/$' | '/docs'
-  id: '__root__' | '/' | '/docs' | '/api/search' | '/docs/$' | '/docs/'
+  to: '/' | '/api/search' | '/blog/$slug' | '/docs/$' | '/blog' | '/docs'
+  id:
+    | '__root__'
+    | '/'
+    | '/blog'
+    | '/docs'
+    | '/api/search'
+    | '/blog/$slug'
+    | '/docs/$'
+    | '/blog/'
+    | '/docs/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  BlogRoute: typeof BlogRouteWithChildren
   DocsRoute: typeof DocsRouteWithChildren
   ApiSearchRoute: typeof ApiSearchRoute
 }
@@ -83,6 +127,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/blog': {
+      id: '/blog'
+      path: '/blog'
+      fullPath: '/blog'
+      preLoaderRoute: typeof BlogRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/docs': {
@@ -98,6 +149,20 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/search'
       preLoaderRoute: typeof ApiSearchRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/blog/': {
+      id: '/blog/'
+      path: '/'
+      fullPath: '/blog/'
+      preLoaderRoute: typeof BlogIndexRouteImport
+      parentRoute: typeof BlogRoute
+    }
+    '/blog/$slug': {
+      id: '/blog/$slug'
+      path: '/$slug'
+      fullPath: '/blog/$slug'
+      preLoaderRoute: typeof BlogSlugRouteImport
+      parentRoute: typeof BlogRoute
     }
     '/docs/': {
       id: '/docs/'
@@ -116,6 +181,18 @@ declare module '@tanstack/react-router' {
   }
 }
 
+interface BlogRouteChildren {
+  BlogSlugRoute: typeof BlogSlugRoute
+  BlogIndexRoute: typeof BlogIndexRoute
+}
+
+const BlogRouteChildren: BlogRouteChildren = {
+  BlogSlugRoute: BlogSlugRoute,
+  BlogIndexRoute: BlogIndexRoute,
+}
+
+const BlogRouteWithChildren = BlogRoute._addFileChildren(BlogRouteChildren)
+
 interface DocsRouteChildren {
   DocsSplatRoute: typeof DocsSplatRoute
   DocsIndexRoute: typeof DocsIndexRoute
@@ -130,6 +207,7 @@ const DocsRouteWithChildren = DocsRoute._addFileChildren(DocsRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  BlogRoute: BlogRouteWithChildren,
   DocsRoute: DocsRouteWithChildren,
   ApiSearchRoute: ApiSearchRoute,
 }

--- a/site/src/routes/blog.tsx
+++ b/site/src/routes/blog.tsx
@@ -1,0 +1,25 @@
+import { Outlet, createFileRoute } from "@tanstack/react-router";
+import { HomeLayout } from "fumadocs-ui/layouts/home";
+
+import { baseOptions } from "@/app/layout.config";
+import { SiteFooter } from "@/components/site-footer";
+
+export const Route = createFileRoute("/blog")({
+  component: BlogLayout,
+});
+
+/**
+ * The blog shares the landing page's header and footer rather than the docs
+ * sidebar: a post is read top to bottom, and the docs tree is not its table of
+ * contents.
+ */
+function BlogLayout() {
+  return (
+    <div className="wh-page-scale flex flex-1 flex-col">
+      <HomeLayout {...baseOptions} className="flex-1">
+        <Outlet />
+        <SiteFooter />
+      </HomeLayout>
+    </div>
+  );
+}

--- a/site/src/routes/blog/$slug.tsx
+++ b/site/src/routes/blog/$slug.tsx
@@ -1,0 +1,30 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+
+import { posts } from "@/lib/blog";
+import { postLoader } from "@/lib/mdx-loader";
+import { postHead } from "@/lib/seo";
+
+export const Route = createFileRoute("/blog/$slug")({
+  loader: async ({ params }) => {
+    const post = posts.find((candidate) => candidate.slug === params.slug);
+    if (!post) throw notFound();
+
+    // Load the MDX module before the component renders, so the shell is not
+    // torn down while the post suspends. Same reason as the docs splat route.
+    await postLoader.preload(post.path);
+
+    return post;
+  },
+  head: ({ loaderData }) => {
+    if (!loaderData) return {};
+    return postHead(loaderData);
+  },
+  component: Post,
+});
+
+function Post() {
+  const { path, date } = Route.useLoaderData();
+  const Content = postLoader.getComponent(path);
+
+  return <Content date={date} />;
+}

--- a/site/src/routes/blog/index.tsx
+++ b/site/src/routes/blog/index.tsx
@@ -1,0 +1,42 @@
+import { Link, createFileRoute } from "@tanstack/react-router";
+
+import { formatPostDate, posts } from "@/lib/blog";
+import { blogIndexHead } from "@/lib/seo";
+
+/**
+ * `/blog`: every post newest first with its title, date, and description.
+ *
+ * With zero posts the page still builds, because TanStack Start prerenders
+ * every static route, but nothing links it and the sitemap does not list it,
+ * so a reader only ever reaches it once there is something to read.
+ */
+export const Route = createFileRoute("/blog/")({
+  head: () => blogIndexHead(),
+  component: BlogIndex,
+});
+
+function BlogIndex() {
+  return (
+    <section className="mx-auto w-full max-w-3xl px-5 py-12 lg:px-8">
+      <h1 className="wh-docs-title text-3xl font-semibold sm:text-4xl">Blog</h1>
+      {posts.length === 0 && <p className="mt-6 text-fd-muted-foreground">No posts yet.</p>}
+      <ol className="mt-10 space-y-10">
+        {posts.map((post) => (
+          <li key={post.slug}>
+            <time dateTime={post.date} className="wh-mono-label">
+              {formatPostDate(post.date)}
+            </time>
+            <h2 className="mt-2 text-xl font-semibold tracking-tight">
+              <Link to="/blog/$slug" params={{ slug: post.slug }} className="hover:underline">
+                {post.title}
+              </Link>
+            </h2>
+            <p className="mt-2 text-[15px] leading-relaxed text-fd-muted-foreground">
+              {post.description}
+            </p>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/typescript/core/test/site-smoke.ts
+++ b/typescript/core/test/site-smoke.ts
@@ -205,6 +205,94 @@ try {
     throw new Error("The sitemap claims a modification date that the source does not track");
   }
 
+  // The blog (ADR 0052) ships with zero posts and grows one file at a time.
+  // With a post, the index, the post, its twin, and the feed all resolve and
+  // the section is linked; with none, nothing links `/blog` and the sitemap
+  // does not list it, so an empty page never reaches a reader.
+  const blogIndex = JSON.parse(
+    await readFile(resolve(repositoryRoot, "site/.source/blog-index.json"), "utf8"),
+  ) as { posts: { slug: string; url: string; title: string; date: string }[] };
+  if (blogIndex.posts.length > 0) {
+    const newest = blogIndex.posts[0]!;
+    const index = await fetch(`${baseUrl}/blog`);
+    const indexHtml = await index.text();
+    if (!index.ok) throw new Error(`/blog returned ${index.status}`);
+    assertIncludesTokens(indexHtml, "The blog index", [
+      '<link rel="canonical" href="https://workhorse.run/blog"',
+      '<link rel="alternate" type="application/rss+xml" href="https://workhorse.run/blog/feed.xml"',
+      `href="${newest.url}"`,
+      newest.title,
+    ]);
+    if (!landingHtml.includes('href="/blog"')) {
+      throw new Error("The landing page does not link the blog although it has a post");
+    }
+
+    const postResponse = await fetch(`${baseUrl}${newest.url}`);
+    const postHtml = await postResponse.text();
+    if (!postResponse.ok) throw new Error(`${newest.url} returned ${postResponse.status}`);
+    assertIncludesTokens(postHtml, `The post ${newest.url}`, [
+      `<link rel="canonical" href="https://workhorse.run${newest.url}"`,
+      `<link rel="alternate" type="text/markdown" href="https://workhorse.run${newest.url}.md"`,
+      'property="og:type" content="article"',
+      '"@type":"BlogPosting"',
+      `dateTime="${newest.date}"`,
+    ]);
+
+    const twin = await fetch(`${baseUrl}${newest.url}.md`);
+    const twinText = await twin.text();
+    if (!twin.ok) throw new Error(`${newest.url}.md returned ${twin.status}`);
+    if (!twinText.startsWith(`---\ntitle: ${JSON.stringify(newest.title)}\n`)) {
+      throw new Error(`${newest.url}.md does not start with the twin frontmatter`);
+    }
+    assertIncludesTokens(twinText, `The twin ${newest.url}.md`, [
+      `canonical: "https://workhorse.run${newest.url}"`,
+      `# ${newest.title}`,
+    ]);
+
+    const feed = await fetch(`${baseUrl}/blog/feed.xml`);
+    const feedText = await feed.text();
+    if (!feed.ok) throw new Error(`/blog/feed.xml returned ${feed.status}`);
+    const feedType = feed.headers.get("content-type") ?? "";
+    if (!/xml/.test(feedType)) {
+      throw new Error(`/blog/feed.xml was served as ${feedType || "no content type"}`);
+    }
+    if (!feedText.startsWith('<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0"')) {
+      throw new Error("/blog/feed.xml is not an RSS 2.0 document");
+    }
+    const feedLinks = [...feedText.matchAll(/<item>[\s\S]*?<link>([^<]+)<\/link>/g)].map(
+      (match) => match[1]!,
+    );
+    if (feedLinks.length !== blogIndex.posts.length) {
+      throw new Error(
+        `/blog/feed.xml lists ${feedLinks.length} of ${blogIndex.posts.length} posts`,
+      );
+    }
+    for (const [position, link] of feedLinks.entries()) {
+      const expected = `https://workhorse.run${blogIndex.posts[position]!.url}`;
+      if (link !== expected) {
+        throw new Error(`/blog/feed.xml item ${position} links ${link}, expected ${expected}`);
+      }
+    }
+    for (const url of blogIndex.posts.map((post) => post.url)) {
+      if (!sitemap.includes(`<loc>https://workhorse.run${url}</loc>`)) {
+        throw new Error(`The sitemap omitted the post ${url}`);
+      }
+    }
+    if (!sitemap.includes("<loc>https://workhorse.run/blog</loc>")) {
+      throw new Error("The sitemap omitted the blog index although it has a post");
+    }
+  } else {
+    if (landingHtml.includes('href="/blog"')) {
+      throw new Error("The landing page links the blog although it has no post");
+    }
+    if (quickstartHtml.includes('href="/blog"')) {
+      throw new Error("The quickstart page links the blog although it has no post");
+    }
+    if (sitemap.includes("https://workhorse.run/blog")) {
+      throw new Error("The sitemap lists the blog although it has no post");
+    }
+  }
+
   // Static search ships one prerendered index that the browser downloads and
   // queries locally, so the smoke test checks the index rather than a query.
   const search = await fetch(`${baseUrl}/api/search`);


### PR DESCRIPTION
## Summary

`https://workhorse.run/blog` is the home for long-form content, exactly the minimum ADR 0052 specifies. Closes WH-589.

- **Collection.** `site/content/blog/<slug>.mdx` with `title`, `description`, and `date` (`YYYY-MM-DD`), declared in `site/source.config.ts` beside `docs`. No author field. `.gitkeep` keeps the empty directory.
- **Routes.** `/blog` lists posts newest first with title, date, and description. `/blog/<slug>` renders one post with the documentation prose styling. Both go through `site/lib/seo.ts`: canonical `https://workhorse.run/blog/<slug>`, `og:type` `article`, `article:published_time`, a `BlogPosting` JSON-LD record, and the `text/markdown` alternate. The index carries the feed autodiscovery link.
- **Build outputs.** `gen-docs-index.ts` reads the collection through the new `scripts/blog-posts.ts`, adds `/blog` and every post to `prerender.json` and `sitemap.xml`, writes a twin per post at `/blog/<slug>.md` via `mdx-to-markdown.ts`, and writes an RSS 2.0 feed at `/blog/feed.xml`. `public/blog/` is rebuilt from scratch each build. `llms.txt` and `llms-full.txt` never list a post.
- **Navigation.** "Blog" in the header links and the footer's Project column only when the collection has a post.
- **Conventions.** `site/README.md` documents the collection, the frontmatter, and that post code is not compiled by `check-language-examples.ts`.
- No new dependency, no deployment change. `vite preview` serves `feed.xml` as XML; nginx maps `.xml` already.

## Verification

- `pnpm docs:typecheck` and `pnpm docs:build` pass with zero posts and with one `hello.mdx` post.
- One post: the build output contains `blog/index.html`, `blog/hello/index.html`, `blog/hello.md`, `blog/feed.xml`; `sitemap.xml` lists `/blog` and `/blog/hello`; `llms.txt` and `llms-full.txt` are byte-identical (`cmp`) to the zero-post build. The post head carries the canonical, `og:type` `article`, and the `text/markdown` alternate; the twin starts with `title`, `description`, `canonical` frontmatter.
- Zero posts: no built HTML page contains `href="/blog"` (0 files), the sitemap has no `blog` entry, and `site/public/blog/` does not exist.
- `test:site-smoke` passes in both states with the new blog assertions (feed content type, RSS 2.0 shape, newest-first absolute links, index and post head, twin frontmatter).
- `site/scripts/blog-posts.test.ts` (5 tests) covers ordering, validation errors, and the feed.
- `oxlint --deny-warnings`, `oxfmt --check`, and `knip` pass on the changed files.

The sample post is not committed; `main` ships the section with zero posts.

https://claude.ai/code/session_01Ppyy4YUMWbYq5bnLtMuPjg
