### PR TITLE
[WH-601] Rename valid_tags to valid_tags_v1 and fold the dashboard run-now function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ and 24 and PostgreSQL 15 through 18.
   its URL plus `.md` served as `text/markdown`, and `llms-full.txt` carries the whole corpus.
 - `SECURITY.md` names the private reporting channel and states that only the latest `0.x` minor of
   each package line receives fixes.
+- **Schema.** `workhorse.valid_tags` is renamed `workhorse.valid_tags_v1`, so every function in the
+  schema now carries a version suffix and can be superseded without breaking its callers.
+  `workhorse.dashboard_run_task_now_v1` is removed: the Python and Go dashboard backends now call
+  the audited four-argument `workhorse.run_task_now_v1`, which the TypeScript dashboard server
+  already used. A dashboard run-now action is therefore audited in all three languages, and its
+  `promoted` event records the actor, the reason, and the request identity.
 
 ### Fixed
 
@@ -50,11 +56,13 @@ and 24 and PostgreSQL 15 through 18.
 
 ### Upgrade notes
 
-- **Schema version.** `0.1.0` installs the same schema version 1 baseline that `0.1.0-beta.2`
-  installed; `sql/schema/current.sql` did not change between them, so a database the beta installed
-  passes `assertSchemaCompatible` as it is. The `0.x` rule still applies: there is no upgrade path
-  between `0.x` releases, so when a release changes the schema, recreate the database and install
-  the new baseline with `npx --package @stablemates/workhorse workhorse schema install`.
+- **Schema version.** `0.1.0` stays at schema version 1, but its baseline is not the one
+  `0.1.0-beta.2` installed: `workhorse.valid_tags` was renamed and
+  `workhorse.dashboard_run_task_now_v1` was removed. A database installed by any beta reports
+  version 1 and passes `assertSchemaCompatible`, yet holds the old function names. You must recreate the database and
+  install the new baseline with `npx --package @stablemates/workhorse workhorse schema install`.
+  This is the last release that asks for a recreation: from `0.1.0` the schema is frozen as the
+  migration baseline, and later releases upgrade a database in place.
 
 ## 0.1.0-beta.2 — 2026-09-01
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1669,8 +1669,8 @@ wait. Actor contains 1 through 200 characters, reason contains 1 through 2,000 c
 request ID contains 1 through 512 UTF-8 bytes. A successful release appends one `promoted` event.
 Its details contain `reason = 'manual'`, `requested_by`, `request_reason`,
 `request_id_preview`, the 12-character `request_id_digest`, and `request_id_length`. Calls that do
-not change the job append no event. Dashboard backends use `dashboard_run_task_now_v1(job_id)` for
-the same state transition when their mutation layer supplies the audit boundary.
+not change the job append no event. Every dashboard backend calls this function directly and
+supplies the audit arguments from its authenticated actor and the request's audit envelope.
 
 ## Atomic lifecycle
 
@@ -2778,7 +2778,7 @@ interactive stdin and stdout is refused with exit 1.
   from `notificationPool.options.max`. Without those capabilities, an adapter remains polling-only.
   A pool whose capacity is 1 also remains polling-only, which prevents its sole connection from being
   held away from claims. Queue-name payloads wake matching subscribers and `*` wakes all subscribers.
-  `promote_v1`, `run_task_now_v1`, `dashboard_run_task_now_v1`, `recover_expired_v1`,
+  `promote_v1`, `run_task_now_v1`, `recover_expired_v1`,
   `sync_concurrency_policies_v1`, and `sync_rate_limit_policies_v1` notify once per distinct affected
   queue. Job notifications abort only the dispatch loop's `dispatchWakeController`; maintenance and
   registration retain their configured sleep cadence through `wakeController`. Lifecycle changes

--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -19,14 +19,20 @@ Requires **schema v1** and Go **1.25** or newer.
 
 - No exported API changed since `0.1.0-beta.1`. The README states the unpinned install command and
   the schema install step, which the TypeScript CLI owns.
+- The dashboard backend's run-now action calls the audited `workhorse.run_task_now_v1` instead of
+  `workhorse.dashboard_run_task_now_v1`, which is removed from the schema. The action now records
+  the authenticated actor, the reason, and the request identity in its `promoted` event, matching
+  the TypeScript dashboard server.
 
 ### Upgrade notes
 
-- **Schema version.** `0.1.0` requires the same schema version 1 baseline that `0.1.0-beta.1`
-  required, so a database the beta installed passes `AssertCompatible` as it is. The `0.x` rule
-  still applies: there is no upgrade path between `0.x` releases, so when a release changes the
-  schema, recreate the database and install the new baseline with
-  `npx --package @stablemates/workhorse workhorse schema install`.
+- **Schema version.** `0.1.0` stays at schema version 1, but its baseline is not the one the last
+  beta installed: `workhorse.valid_tags` was renamed `workhorse.valid_tags_v1` and
+  `workhorse.dashboard_run_task_now_v1` was removed. A database installed by any beta reports
+  version 1 and passes the compatibility check, yet holds the old function names. You must recreate the database and
+  install the new baseline with `npx --package @stablemates/workhorse workhorse schema install`.
+  This is the last release that asks for a recreation: from `0.1.0` the schema is frozen as the
+  migration baseline, and later releases upgrade a database in place.
 
 ## 0.1.0-beta.1 — 2026-09-01
 

--- a/go/dashboard/mutations.go
+++ b/go/dashboard/mutations.go
@@ -110,9 +110,10 @@ func (service *backend) revertRetentionPolicy(ctx context.Context, input any, _ 
 	return nil, err
 }
 
-func (service *backend) runTaskNow(ctx context.Context, input any, _ string) (any, error) {
+func (service *backend) runTaskNow(ctx context.Context, input any, actor string) (any, error) {
 	value, _ := document(input)
-	rows, err := service.executor.Query(ctx, "SELECT status,state,run_at FROM workhorse.dashboard_run_task_now_v1($1::uuid)", value["id"])
+	audit := value["audit"].(map[string]any)
+	rows, err := service.executor.Query(ctx, "SELECT status,state,run_at FROM workhorse.run_task_now_v1($1::uuid,$2::text,$3::text,$4::text)", value["id"], actor, audit["reason"], audit["requestId"])
 	if err != nil {
 		return nil, err
 	}

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -34,14 +34,20 @@ Requires **schema v1** and Python **3.12** or newer.
 
 - The README states the unpinned install command and the schema install step, which the TypeScript
   CLI owns.
+- The dashboard backend's run-now action calls the audited `workhorse.run_task_now_v1` instead of
+  `workhorse.dashboard_run_task_now_v1`, which is removed from the schema. The action now records
+  the authenticated actor, the reason, and the request identity in its `promoted` event, matching
+  the TypeScript dashboard server.
 
 ### Upgrade notes
 
-- **Schema version.** `0.1.0` requires the same schema version 1 baseline that `0.1.0b3` required,
-  so a database the beta installed passes `assert_schema_compatible` as it is. The `0.x` rule still
-  applies: there is no upgrade path between `0.x` releases, so when a release changes the schema,
-  recreate the database and install the new baseline with
-  `npx --package @stablemates/workhorse workhorse schema install`.
+- **Schema version.** `0.1.0` stays at schema version 1, but its baseline is not the one the last
+  beta installed: `workhorse.valid_tags` was renamed `workhorse.valid_tags_v1` and
+  `workhorse.dashboard_run_task_now_v1` was removed. A database installed by any beta reports
+  version 1 and passes the compatibility check, yet holds the old function names. You must recreate the database and
+  install the new baseline with `npx --package @stablemates/workhorse workhorse schema install`.
+  This is the last release that asks for a recreation: from `0.1.0` the schema is frozen as the
+  migration baseline, and later releases upgrade a database in place.
 
 ## 0.1.0b3 — 2026-09-01
 

--- a/python/src/workhorse/dashboard/_backend.py
+++ b/python/src/workhorse/dashboard/_backend.py
@@ -338,11 +338,16 @@ class DashboardBackend:
             ([_camel_to_snake(name) for name in settings],),
         )
 
-    def run_task_now(self, input: object, _actor: str) -> object:
-        job_id = cast(Mapping[str, object], input)["id"]
+    def run_task_now(self, input: object, actor: str) -> object:
+        value = cast(Mapping[str, object], input)
+        audit = cast(Mapping[str, object], value["audit"])
+        job_id = value["id"]
         row = self._rows(
-            "SELECT status, state, run_at FROM workhorse.dashboard_run_task_now_v1(%s::uuid)",
-            (job_id,),
+            """
+            SELECT status, state, run_at FROM workhorse.run_task_now_v1(
+              %s::uuid, %s::text, %s::text, %s::text)
+            """,
+            (job_id, actor, audit["reason"], audit["requestId"]),
         )[0]
         if row["status"] == "not_found":
             raise DashboardRPCError(404, "NOT_FOUND", "Task not found")

--- a/sql/schema/current.sql
+++ b/sql/schema/current.sql
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS workhorse.protocol_version (
   recorded_at timestamptz NOT NULL DEFAULT clock_timestamp()
 );
 
-CREATE OR REPLACE FUNCTION workhorse.valid_tags(p_tags text[])
+CREATE OR REPLACE FUNCTION workhorse.valid_tags_v1(p_tags text[])
 RETURNS boolean
 LANGUAGE sql
 IMMUTABLE
@@ -437,7 +437,7 @@ CREATE TABLE IF NOT EXISTS workhorse.job (
   trace_context jsonb
     CONSTRAINT job_trace_context_valid CHECK (workhorse.valid_trace_context_v1(trace_context)),
   tags text[] NOT NULL DEFAULT '{}'
-    CONSTRAINT job_tags_valid CHECK (workhorse.valid_tags(tags)),
+    CONSTRAINT job_tags_valid CHECK (workhorse.valid_tags_v1(tags)),
   max_attempts integer NOT NULL CHECK (max_attempts BETWEEN 1 AND 100),
   retry_policy jsonb
     CONSTRAINT job_retry_policy_normalized CHECK (
@@ -5559,7 +5559,7 @@ BEGIN
     END IF;
     SELECT COALESCE(array_agg(value), '{}') INTO v_tags
       FROM jsonb_array_elements_text(v_filter->'tags') tag(value);
-    IF NOT workhorse.valid_tags(v_tags) THEN
+    IF NOT workhorse.valid_tags_v1(v_tags) THEN
       RAISE EXCEPTION 'dead-letter tags filter must contain at most 20 non-empty tags of at most 100 characters';
     END IF;
   END IF;
@@ -5835,7 +5835,7 @@ BEGIN
     END IF;
     SELECT COALESCE(array_agg(value), '{}') INTO v_tags
       FROM jsonb_array_elements_text(v_filter->'tags') tag(value);
-    IF NOT workhorse.valid_tags(v_tags) THEN
+    IF NOT workhorse.valid_tags_v1(v_tags) THEN
       RAISE EXCEPTION 'bulk redrive tags filter must contain at most 20 non-empty tags of at most 100 characters';
     END IF;
   END IF;
@@ -6393,74 +6393,6 @@ BEGIN
     PERFORM pg_notify('workhorse_jobs', v_notify_queue);
   END LOOP;
   RETURN v_count;
-END;
-$$;
-
--- Release one ordinary future-scheduled task without bypassing a durable wait. This operator path
--- deliberately changes only the task occurrence. It never reads or updates schedule_definition or
--- schedule_occurrence, so a recurring schedule's cadence and next evaluation remain untouched.
-CREATE OR REPLACE FUNCTION workhorse.dashboard_run_task_now_v1(p_job_id uuid)
-RETURNS TABLE(status text, state text, run_at timestamptz)
-LANGUAGE plpgsql
-AS $$
-DECLARE
-  v_runtime workhorse.job_runtime%ROWTYPE;
-  v_outcome workhorse.job_outcome%ROWTYPE;
-  v_now timestamptz := clock_timestamp();
-BEGIN
-  SELECT * INTO v_runtime
-    FROM workhorse.job_runtime runtime
-   WHERE runtime.job_id = p_job_id
-   FOR UPDATE;
-
-  IF FOUND THEN
-    IF v_runtime.state IN ('ready', 'active') THEN
-      RETURN QUERY VALUES ('already_ready'::text, v_runtime.state, v_runtime.run_at);
-      RETURN;
-    END IF;
-
-    -- A scheduled row with a retained attempt is suspended at a durable wait boundary. Releasing it
-    -- would skip the named wait and violate durable execution semantics, so refuse even if wait_name
-    -- is momentarily unavailable due to a racing reader.
-    IF v_runtime.wait_name IS NOT NULL OR v_runtime.attempt_started_at IS NOT NULL THEN
-      RETURN QUERY VALUES ('waiting'::text, v_runtime.state, v_runtime.run_at);
-      RETURN;
-    END IF;
-
-    UPDATE workhorse.job_runtime runtime
-       SET state = 'ready', run_at = v_now, ready_at = v_now,
-           sequence = nextval('workhorse.ready_sequence_seq'), updated_at = v_now
-     WHERE runtime.job_id = p_job_id AND runtime.state = 'scheduled'
-    RETURNING * INTO v_runtime;
-    IF NOT FOUND THEN
-      RAISE EXCEPTION 'locked scheduled task % changed state unexpectedly', p_job_id;
-    END IF;
-
-    INSERT INTO workhorse.job_event(job_id, attempt, event_type, details)
-      VALUES (
-        p_job_id,
-        v_runtime.current_attempt,
-        'promoted',
-        jsonb_build_object('reason', 'manual')
-      );
-    PERFORM pg_notify('workhorse_jobs', v_runtime.queue_name);
-    RETURN QUERY VALUES ('released'::text, v_runtime.state, v_runtime.run_at);
-    RETURN;
-  END IF;
-
-  SELECT * INTO v_outcome
-    FROM workhorse.job_outcome outcome
-   WHERE outcome.job_id = p_job_id;
-  IF FOUND THEN
-    RETURN QUERY VALUES ('not_scheduled'::text, v_outcome.state, v_outcome.run_at);
-    RETURN;
-  END IF;
-
-  IF EXISTS (SELECT 1 FROM workhorse.job job WHERE job.id = p_job_id) THEN
-    RETURN QUERY VALUES ('not_scheduled'::text, NULL::text, NULL::timestamptz);
-  ELSE
-    RETURN QUERY VALUES ('not_found'::text, NULL::text, NULL::timestamptz);
-  END IF;
 END;
 $$;
 

--- a/typescript/core/test/schema-installation.test.ts
+++ b/typescript/core/test/schema-installation.test.ts
@@ -377,6 +377,24 @@ describe("schema installation", () => {
     expect(versioned.rows).toEqual([]);
   });
 
+  it("gives every function and view a version suffix", async () => {
+    // An unsuffixed name cannot be superseded without breaking its callers, because there is no
+    // second name to move to. `docs/schema-lifecycle.md` requires the suffix on every one.
+    const unsuffixed = await pool.query<{ name: string }>(
+      `SELECT proname AS name
+         FROM pg_proc
+         JOIN pg_namespace ON pg_namespace.oid = pg_proc.pronamespace
+        WHERE nspname = 'workhorse' AND proname !~ '_v[0-9]+$'
+        UNION ALL
+       SELECT relname AS name
+         FROM pg_class
+         JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+        WHERE nspname = 'workhorse' AND relkind = 'v' AND relname !~ '_v[0-9]+$'
+        ORDER BY name`,
+    );
+    expect(unsuffixed.rows).toEqual([]);
+  });
+
   it("installs schema v1 with database-owned settings, job contracts, and fenced progress", async () => {
     const version = await pool.query<{ version: number }>(
       "SELECT max(version)::integer AS version FROM workhorse.schema_version",


### PR DESCRIPTION
Closes WH-601.

Every function in the `workhorse` schema now carries a version suffix. `workhorse.valid_tags` was the last unsuffixed name, so nothing could supersede it without breaking its callers. It backs the `job_tags_valid` CHECK constraint and two filter validators; a PostgreSQL function rename carries the stored constraint expression with it, so the constraint needed no separate edit.

`workhorse.dashboard_run_task_now_v1` duplicated the state transition of the audited four-argument `run_task_now_v1` without recording who asked for it. The TypeScript dashboard server already routed `Admin.runTaskNow` through the audited function while the Python and Go backends called the unaudited variant — the same operator action produced a `promoted` event with an actor in one language and without one in the other two. Both backends now call `run_task_now_v1` with the authenticated actor and the request's audit envelope, which `auditSchema` in the dashboard contract already requires. The duplicate function is removed.

## Verification

```
$ grep -oP 'CREATE (?:OR REPLACE )?FUNCTION workhorse\.\K[a-z0-9_]+' sql/schema/current.sql \
    | sort -u | grep -vc '_v[0-9]\+$'
0
$ grep -rn "dashboard_run_task_now|valid_tags[^_]" --include='*.ts' --include='*.py' --include='*.go' \
    --include='*.json' --include='*.sql' .   # excluding node_modules and dist
(no matches)
```

- `vitest run` — 1678 passed (140 files)
- `pytest python/tests` — 155 passed
- `go test ./...` — all packages ok
- `test:protocol` (SQL protocol conformance + schema migrations) — 18 passed
- `sql-catalogues:check` and the parity table check — clean

A new assertion in `schema-installation.test.ts` fails any function or view that lacks a version suffix, next to the existing one that fails any version above `v1`.

## Notes

The manifest needed no edit: `dashboard_run_task_now_v1` was never a catalogue statement, because the Python and Go backends carried its SQL inline.

This changes the schema, so the 0.1.0 baseline is no longer the one the betas installed. All three changelogs say so and keep the recreate-the-database instruction. Backward compatibility with the betas is out of scope — the only live instance is the demo.

`runTaskNow` is an optional dashboard procedure with no shared conformance scenario, so this cross-language change is covered by unit and type checks rather than by the shared HTTP contract suite. Filed separately.

https://claude.ai/code/session_01LbQjiy3riBwzkuXmReRNwb