### PR TITLE
Cover the run-now audit trail and both refusals in the shared conformance suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ and 24 and PostgreSQL 15 through 18.
   `0.1.0-beta.2` installed: `workhorse.valid_tags` was renamed and
   `workhorse.dashboard_run_task_now_v1` was removed. A database installed by any beta reports
   version 1 and passes `assertSchemaCompatible`, yet holds the old function names. You must recreate the database and
-  install the new baseline with `npx --package @stablemates/workhorse workhorse schema install`.
+  install the new baseline with `npm exec --no -- workhorse schema install`.
   This is the last release that asks for a recreation: from `0.1.0` the schema is frozen as the
   migration baseline, and later releases upgrade a database in place.
 

--- a/dashboard/v1/README.md
+++ b/dashboard/v1/README.md
@@ -169,6 +169,13 @@ value of that shape (`uuid`, `timestamp`, `string`, `integer`, `number`, `boolea
 where the concrete value is inherently nondeterministic — generated identifiers, clock-derived
 timestamps, durations, and time-bucketed series.
 
+Every timestamp in a response body is UTC with exactly three fractional digits, the format
+JavaScript `Date.toISOString()` writes: `2026-09-02T14:30:00.000Z`. One instant has one string, so
+a backend may not drop a trailing zero or pass through the microsecond precision PostgreSQL
+supplies. Most timestamps in the fixtures are clock-derived and match through `{"$type":
+"timestamp"}`, which hides a format difference; the fixed far-future `run_at` of a task waiting at
+a durable signal is committed literally and does not.
+
 The fixtures must cover every procedure in `manifest.json` with a successful exchange, every
 mutation with both a cross-origin rejection and a read-only `FORBIDDEN` exchange, and the 400,
 404, and 405 error envelopes; the verifier fails the run when any of that coverage is missing.

--- a/dashboard/v1/conformance.json
+++ b/dashboard/v1/conformance.json
@@ -6053,6 +6053,32 @@
           }
         },
         {
+          "id": "enqueue-test-feature",
+          "procedure": "enqueueTest",
+          "request": {
+            "json": {
+              "kind": "feature",
+              "feature": "signals",
+              "priority": 0,
+              "audit": {
+                "actor": "browser-operator",
+                "reason": "conformance exchange",
+                "requestId": "conformance-request"
+              }
+            }
+          },
+          "expect": {
+            "status": 200,
+            "body": {
+              "json": {
+                "jobId": {
+                  "$type": "uuid"
+                }
+              }
+            }
+          }
+        },
+        {
           "id": "set-schedule-enabled",
           "procedure": "setScheduleEnabled",
           "request": {
@@ -6252,6 +6278,165 @@
                 "runAt": {
                   "$type": "timestamp"
                 }
+              }
+            }
+          }
+        },
+        {
+          "id": "run-task-now-promoted-event",
+          "procedure": "events",
+          "request": {
+            "json": {
+              "window": "1h",
+              "pageSize": 25,
+              "types": [
+                "promoted"
+              ],
+              "jobId": {
+                "$ref": "scheduledJob"
+              }
+            }
+          },
+          "expect": {
+            "status": 200,
+            "body": {
+              "json": {
+                "page": 1,
+                "total": 1,
+                "events": [
+                  {
+                    "id": {
+                      "$type": "string"
+                    },
+                    "kind": "event",
+                    "type": "promoted",
+                    "jobId": {
+                      "$ref": "scheduledJob"
+                    },
+                    "queue": "conformance",
+                    "attempt": 1,
+                    "details": {
+                      "reason": "manual",
+                      "requested_by": "conformance",
+                      "request_reason": "conformance exchange",
+                      "request_id_digest": "d4e9bf8d68c9",
+                      "request_id_length": 19,
+                      "request_id_preview": "conforma…uest"
+                    },
+                    "jobType": "conformance.scheduled",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
+                    "workerId": null,
+                    "durationMs": null,
+                    "fenceToken": null,
+                    "occurredAt": {
+                      "$type": "timestamp"
+                    },
+                    "errorMessage": null
+                  }
+                ],
+                "window": "1h",
+                "pageSize": 25,
+                "retention": {
+                  "jobEventDays": 14,
+                  "attemptHistoryDays": 14
+                },
+                "capturedAt": {
+                  "$type": "timestamp"
+                },
+                "windowSeconds": 3600
+              }
+            }
+          }
+        },
+        {
+          "id": "run-task-now-repeat",
+          "procedure": "runTaskNow",
+          "request": {
+            "json": {
+              "id": {
+                "$ref": "scheduledJob"
+              },
+              "audit": {
+                "actor": "browser-operator",
+                "reason": "conformance exchange",
+                "requestId": "conformance-request"
+              }
+            }
+          },
+          "expect": {
+            "status": 200,
+            "body": {
+              "json": {
+                "status": "already_ready",
+                "id": {
+                  "$ref": "scheduledJob"
+                },
+                "state": "ready",
+                "runAt": {
+                  "$type": "timestamp"
+                }
+              }
+            }
+          }
+        },
+        {
+          "id": "run-task-now-already-ready",
+          "procedure": "runTaskNow",
+          "request": {
+            "json": {
+              "id": {
+                "$ref": "readyJob"
+              },
+              "audit": {
+                "actor": "browser-operator",
+                "reason": "conformance exchange",
+                "requestId": "conformance-request"
+              }
+            }
+          },
+          "expect": {
+            "status": 200,
+            "body": {
+              "json": {
+                "status": "already_ready",
+                "id": {
+                  "$ref": "readyJob"
+                },
+                "state": "ready",
+                "runAt": {
+                  "$type": "timestamp"
+                }
+              }
+            }
+          }
+        },
+        {
+          "id": "run-task-now-waiting",
+          "procedure": "runTaskNow",
+          "request": {
+            "json": {
+              "id": {
+                "$ref": "signalJob"
+              },
+              "audit": {
+                "actor": "browser-operator",
+                "reason": "conformance exchange",
+                "requestId": "conformance-request"
+              }
+            }
+          },
+          "expect": {
+            "status": 200,
+            "body": {
+              "json": {
+                "status": "waiting",
+                "id": {
+                  "$ref": "signalJob"
+                },
+                "state": "scheduled",
+                "runAt": "9999-12-31T00:00:00.000Z"
               }
             }
           }

--- a/dashboard/v1/conformance.json
+++ b/dashboard/v1/conformance.json
@@ -601,15 +601,15 @@
             "body": {
               "json": {
                 "all": 8,
-                "blocked": 0,
-                "waiting": 2,
-                "scheduled": 3,
-                "retried": 0,
                 "queued": 3,
+                "blocked": 0,
+                "retried": 0,
                 "running": 0,
+                "waiting": 2,
+                "canceled": 0,
                 "completed": 1,
                 "discarded": 1,
-                "canceled": 0
+                "scheduled": 3
               }
             }
           }
@@ -624,208 +624,178 @@
             "status": 200,
             "body": {
               "json": {
-                "capturedAt": {
-                  "$type": "timestamp"
-                },
-                "canCompleteHumanWait": true,
-                "filter": "all",
-                "queue": null,
-                "worker": null,
-                "jobType": null,
-                "priority": null,
-                "sort": "updated",
-                "tags": [],
-                "search": null,
-                "page": 1,
-                "pageSize": 50,
-                "total": 8,
                 "jobs": [
                   {
                     "id": {
                       "$ref": "purgeTargetJob"
                     },
-                    "queue": "conformance-purge",
-                    "type": "conformance.purge",
-                    "priority": 0,
-                    "state": "ready",
-                    "blockedReason": null,
-                    "prerequisiteJobIds": [],
-                    "attempt": 1,
-                    "maxAttempts": 25,
-                    "retryPolicy": null,
-                    "deadlineAt": null,
-                    "executionTimeoutMs": null,
                     "tags": [],
+                    "type": "conformance.purge",
+                    "wait": null,
                     "keyed": false,
-                    "cancellation": null,
+                    "queue": "conformance-purge",
                     "runAt": {
                       "$type": "timestamp"
                     },
+                    "state": "ready",
+                    "wakeAt": null,
+                    "attempt": 1,
+                    "priority": 0,
+                    "waitName": null,
                     "workerId": null,
-                    "lastWorkerId": null,
-                    "finishedAt": null,
-                    "errorMessage": null,
                     "createdAt": {
                       "$type": "timestamp"
                     },
+                    "humanWait": null,
                     "updatedAt": {
                       "$type": "timestamp"
                     },
+                    "deadlineAt": null,
                     "durability": null,
-                    "waitName": null,
-                    "wakeAt": null,
-                    "wait": null,
+                    "finishedAt": null,
                     "signalWait": null,
-                    "humanWait": null
+                    "maxAttempts": 25,
+                    "retryPolicy": null,
+                    "cancellation": null,
+                    "errorMessage": null,
+                    "lastWorkerId": null,
+                    "blockedReason": null,
+                    "executionTimeoutMs": null,
+                    "prerequisiteJobIds": []
                   },
                   {
                     "id": {
                       "$ref": "cancelTargetJob"
                     },
-                    "queue": "conformance",
-                    "type": "conformance.cancel-target",
-                    "priority": 0,
-                    "state": "ready",
-                    "blockedReason": null,
-                    "prerequisiteJobIds": [],
-                    "attempt": 1,
-                    "maxAttempts": 25,
-                    "retryPolicy": null,
-                    "deadlineAt": null,
-                    "executionTimeoutMs": null,
                     "tags": [],
+                    "type": "conformance.cancel-target",
+                    "wait": null,
                     "keyed": false,
-                    "cancellation": null,
+                    "queue": "conformance",
                     "runAt": {
                       "$type": "timestamp"
                     },
+                    "state": "ready",
+                    "wakeAt": null,
+                    "attempt": 1,
+                    "priority": 0,
+                    "waitName": null,
                     "workerId": null,
-                    "lastWorkerId": null,
-                    "finishedAt": null,
-                    "errorMessage": null,
                     "createdAt": {
                       "$type": "timestamp"
                     },
+                    "humanWait": null,
                     "updatedAt": {
                       "$type": "timestamp"
                     },
+                    "deadlineAt": null,
                     "durability": null,
-                    "waitName": null,
-                    "wakeAt": null,
-                    "wait": null,
+                    "finishedAt": null,
                     "signalWait": null,
-                    "humanWait": null
+                    "maxAttempts": 25,
+                    "retryPolicy": null,
+                    "cancellation": null,
+                    "errorMessage": null,
+                    "lastWorkerId": null,
+                    "blockedReason": null,
+                    "executionTimeoutMs": null,
+                    "prerequisiteJobIds": []
                   },
                   {
                     "id": {
                       "$ref": "scheduledJob"
                     },
-                    "queue": "conformance",
-                    "type": "conformance.scheduled",
-                    "priority": 0,
-                    "state": "scheduled",
-                    "blockedReason": null,
-                    "prerequisiteJobIds": [],
-                    "attempt": 1,
-                    "maxAttempts": 25,
-                    "retryPolicy": null,
-                    "deadlineAt": null,
-                    "executionTimeoutMs": null,
                     "tags": [],
+                    "type": "conformance.scheduled",
+                    "wait": null,
                     "keyed": false,
-                    "cancellation": null,
+                    "queue": "conformance",
                     "runAt": "2031-01-01T00:00:00.000Z",
+                    "state": "scheduled",
+                    "wakeAt": null,
+                    "attempt": 1,
+                    "priority": 0,
+                    "waitName": null,
                     "workerId": null,
-                    "lastWorkerId": null,
-                    "finishedAt": null,
-                    "errorMessage": null,
                     "createdAt": {
                       "$type": "timestamp"
                     },
+                    "humanWait": null,
                     "updatedAt": {
                       "$type": "timestamp"
                     },
+                    "deadlineAt": null,
                     "durability": null,
-                    "waitName": null,
-                    "wakeAt": null,
-                    "wait": null,
+                    "finishedAt": null,
                     "signalWait": null,
-                    "humanWait": null
+                    "maxAttempts": 25,
+                    "retryPolicy": null,
+                    "cancellation": null,
+                    "errorMessage": null,
+                    "lastWorkerId": null,
+                    "blockedReason": null,
+                    "executionTimeoutMs": null,
+                    "prerequisiteJobIds": []
                   },
                   {
                     "id": {
                       "$ref": "readyJob"
                     },
-                    "queue": "conformance",
-                    "type": "conformance.ready",
-                    "priority": 5,
-                    "state": "ready",
-                    "blockedReason": null,
-                    "prerequisiteJobIds": [],
-                    "attempt": 1,
-                    "maxAttempts": 25,
-                    "retryPolicy": null,
-                    "deadlineAt": null,
-                    "executionTimeoutMs": null,
                     "tags": [
                       "conformance"
                     ],
+                    "type": "conformance.ready",
+                    "wait": null,
                     "keyed": false,
-                    "cancellation": null,
+                    "queue": "conformance",
                     "runAt": {
                       "$type": "timestamp"
                     },
+                    "state": "ready",
+                    "wakeAt": null,
+                    "attempt": 1,
+                    "priority": 5,
+                    "waitName": null,
                     "workerId": null,
-                    "lastWorkerId": null,
-                    "finishedAt": null,
-                    "errorMessage": null,
                     "createdAt": {
                       "$type": "timestamp"
                     },
+                    "humanWait": null,
                     "updatedAt": {
                       "$type": "timestamp"
                     },
+                    "deadlineAt": null,
                     "durability": null,
-                    "waitName": null,
-                    "wakeAt": null,
-                    "wait": null,
+                    "finishedAt": null,
                     "signalWait": null,
-                    "humanWait": null
+                    "maxAttempts": 25,
+                    "retryPolicy": null,
+                    "cancellation": null,
+                    "errorMessage": null,
+                    "lastWorkerId": null,
+                    "blockedReason": null,
+                    "executionTimeoutMs": null,
+                    "prerequisiteJobIds": []
                   },
                   {
                     "id": {
                       "$ref": "humanJob"
                     },
-                    "queue": "conformance",
-                    "type": "conformance.human",
-                    "priority": 0,
-                    "state": "scheduled",
-                    "blockedReason": null,
-                    "prerequisiteJobIds": [],
-                    "attempt": 1,
-                    "maxAttempts": 25,
-                    "retryPolicy": null,
-                    "deadlineAt": null,
-                    "executionTimeoutMs": null,
                     "tags": [],
+                    "type": "conformance.human",
+                    "wait": null,
                     "keyed": false,
-                    "cancellation": null,
+                    "queue": "conformance",
                     "runAt": "9999-12-31T00:00:00.000Z",
+                    "state": "scheduled",
+                    "wakeAt": null,
+                    "attempt": 1,
+                    "priority": 0,
+                    "waitName": "review",
                     "workerId": null,
-                    "lastWorkerId": null,
-                    "finishedAt": null,
-                    "errorMessage": null,
                     "createdAt": {
                       "$type": "timestamp"
                     },
-                    "updatedAt": {
-                      "$type": "timestamp"
-                    },
-                    "durability": null,
-                    "waitName": "review",
-                    "wakeAt": null,
-                    "wait": null,
-                    "signalWait": null,
                     "humanWait": {
                       "name": "review",
                       "context": {
@@ -834,132 +804,162 @@
                       "deadlineAt": {
                         "$type": "timestamp"
                       }
-                    }
+                    },
+                    "updatedAt": {
+                      "$type": "timestamp"
+                    },
+                    "deadlineAt": null,
+                    "durability": null,
+                    "finishedAt": null,
+                    "signalWait": null,
+                    "maxAttempts": 25,
+                    "retryPolicy": null,
+                    "cancellation": null,
+                    "errorMessage": null,
+                    "lastWorkerId": null,
+                    "blockedReason": null,
+                    "executionTimeoutMs": null,
+                    "prerequisiteJobIds": []
                   },
                   {
                     "id": {
                       "$ref": "signalJob"
                     },
-                    "queue": "conformance",
-                    "type": "conformance.signal",
-                    "priority": 0,
-                    "state": "scheduled",
-                    "blockedReason": null,
-                    "prerequisiteJobIds": [],
-                    "attempt": 1,
-                    "maxAttempts": 25,
-                    "retryPolicy": null,
-                    "deadlineAt": null,
-                    "executionTimeoutMs": null,
                     "tags": [],
+                    "type": "conformance.signal",
+                    "wait": null,
                     "keyed": false,
-                    "cancellation": null,
+                    "queue": "conformance",
                     "runAt": "9999-12-31T00:00:00.000Z",
+                    "state": "scheduled",
+                    "wakeAt": null,
+                    "attempt": 1,
+                    "priority": 0,
+                    "waitName": "approval",
                     "workerId": null,
-                    "lastWorkerId": null,
-                    "finishedAt": null,
-                    "errorMessage": null,
                     "createdAt": {
                       "$type": "timestamp"
                     },
+                    "humanWait": null,
                     "updatedAt": {
                       "$type": "timestamp"
                     },
+                    "deadlineAt": null,
                     "durability": null,
-                    "waitName": "approval",
-                    "wakeAt": null,
-                    "wait": null,
+                    "finishedAt": null,
                     "signalWait": {
                       "name": "approval",
                       "deadlineAt": {
                         "$type": "timestamp"
                       }
                     },
-                    "humanWait": null
+                    "maxAttempts": 25,
+                    "retryPolicy": null,
+                    "cancellation": null,
+                    "errorMessage": null,
+                    "lastWorkerId": null,
+                    "blockedReason": null,
+                    "executionTimeoutMs": null,
+                    "prerequisiteJobIds": []
                   },
                   {
                     "id": {
                       "$ref": "failedJob"
                     },
-                    "queue": "conformance",
-                    "type": "conformance.fail",
-                    "priority": 0,
-                    "state": "failed",
-                    "blockedReason": null,
-                    "prerequisiteJobIds": [],
-                    "attempt": 1,
-                    "maxAttempts": 1,
-                    "retryPolicy": null,
-                    "deadlineAt": null,
-                    "executionTimeoutMs": null,
                     "tags": [],
+                    "type": "conformance.fail",
+                    "wait": null,
                     "keyed": false,
-                    "cancellation": null,
+                    "queue": "conformance",
                     "runAt": {
                       "$type": "timestamp"
                     },
+                    "state": "failed",
+                    "wakeAt": null,
+                    "attempt": 1,
+                    "priority": 0,
+                    "waitName": null,
                     "workerId": null,
-                    "lastWorkerId": null,
-                    "finishedAt": {
-                      "$type": "timestamp"
-                    },
-                    "errorMessage": "conformance.fail failed",
                     "createdAt": {
                       "$type": "timestamp"
                     },
+                    "humanWait": null,
                     "updatedAt": {
                       "$type": "timestamp"
                     },
+                    "deadlineAt": null,
                     "durability": null,
-                    "waitName": null,
-                    "wakeAt": null,
-                    "wait": null,
+                    "finishedAt": {
+                      "$type": "timestamp"
+                    },
                     "signalWait": null,
-                    "humanWait": null
+                    "maxAttempts": 1,
+                    "retryPolicy": null,
+                    "cancellation": null,
+                    "errorMessage": "conformance.fail failed",
+                    "lastWorkerId": null,
+                    "blockedReason": null,
+                    "executionTimeoutMs": null,
+                    "prerequisiteJobIds": []
                   },
                   {
                     "id": {
                       "$ref": "succeededJob"
                     },
-                    "queue": "conformance",
-                    "type": "conformance.succeed",
-                    "priority": 0,
-                    "state": "succeeded",
-                    "blockedReason": null,
-                    "prerequisiteJobIds": [],
-                    "attempt": 1,
-                    "maxAttempts": 25,
-                    "retryPolicy": null,
-                    "deadlineAt": null,
-                    "executionTimeoutMs": null,
                     "tags": [
                       "conformance"
                     ],
+                    "type": "conformance.succeed",
+                    "wait": null,
                     "keyed": false,
-                    "cancellation": null,
+                    "queue": "conformance",
                     "runAt": {
                       "$type": "timestamp"
                     },
+                    "state": "succeeded",
+                    "wakeAt": null,
+                    "attempt": 1,
+                    "priority": 0,
+                    "waitName": null,
                     "workerId": null,
-                    "lastWorkerId": null,
-                    "finishedAt": {
-                      "$type": "timestamp"
-                    },
-                    "errorMessage": null,
                     "createdAt": {
                       "$type": "timestamp"
                     },
+                    "humanWait": null,
                     "updatedAt": {
                       "$type": "timestamp"
                     },
+                    "deadlineAt": null,
                     "durability": null,
-                    "waitName": null,
-                    "wakeAt": null,
-                    "wait": null,
+                    "finishedAt": {
+                      "$type": "timestamp"
+                    },
                     "signalWait": null,
-                    "humanWait": null
+                    "maxAttempts": 25,
+                    "retryPolicy": null,
+                    "cancellation": null,
+                    "errorMessage": null,
+                    "lastWorkerId": null,
+                    "blockedReason": null,
+                    "executionTimeoutMs": null,
+                    "prerequisiteJobIds": []
                   }
-                ]
+                ],
+                "page": 1,
+                "sort": "updated",
+                "tags": [],
+                "queue": null,
+                "total": 8,
+                "filter": "all",
+                "search": null,
+                "worker": null,
+                "jobType": null,
+                "pageSize": 50,
+                "priority": null,
+                "capturedAt": {
+                  "$type": "timestamp"
+                },
+                "canCompleteHumanWait": true
               }
             }
           }
@@ -980,24 +980,24 @@
             "status": 200,
             "body": {
               "json": {
-                "capturedAt": {
-                  "$type": "timestamp"
-                },
-                "canCompleteHumanWait": true,
-                "filter": "discarded",
-                "queue": null,
-                "worker": null,
-                "jobType": null,
-                "priority": null,
+                "jobs": [],
+                "page": 1,
                 "sort": "priority",
                 "tags": [
                   "conformance"
                 ],
-                "search": null,
-                "page": 1,
-                "pageSize": 50,
+                "queue": null,
                 "total": 0,
-                "jobs": []
+                "filter": "discarded",
+                "search": null,
+                "worker": null,
+                "jobType": null,
+                "pageSize": 50,
+                "priority": null,
+                "capturedAt": {
+                  "$type": "timestamp"
+                },
+                "canCompleteHumanWait": true
               }
             }
           }
@@ -1010,6 +1010,9 @@
             "status": 200,
             "body": {
               "json": {
+                "tags": [
+                  "conformance"
+                ],
                 "queues": [
                   "conformance",
                   "conformance-purge"
@@ -1026,9 +1029,6 @@
                   "conformance.scheduled",
                   "conformance.signal",
                   "conformance.succeed"
-                ],
-                "tags": [
-                  "conformance"
                 ]
               }
             }
@@ -1047,13 +1047,7 @@
             "status": 200,
             "body": {
               "json": {
-                "capturedAt": {
-                  "$type": "timestamp"
-                },
                 "filter": "all",
-                "period": "1h",
-                "groupBy": "task",
-                "bucketSeconds": 120,
                 "groups": [
                   "conformance.cancel-target",
                   "conformance.fail",
@@ -1064,248 +1058,254 @@
                   "conformance.signal",
                   "conformance.succeed"
                 ],
+                "period": "1h",
                 "buckets": [
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
-                    },
                     "counts": {
                       "$type": "any"
+                    },
+                    "bucketStart": {
+                      "$type": "timestamp"
                     }
                   }
-                ]
+                ],
+                "groupBy": "task",
+                "capturedAt": {
+                  "$type": "timestamp"
+                },
+                "bucketSeconds": 120
               }
             }
           },
@@ -1327,37 +1327,20 @@
             "status": 200,
             "body": {
               "json": {
-                "capturedAt": {
-                  "$type": "timestamp"
-                },
-                "window": "1h",
-                "windowSeconds": 3600,
                 "page": 1,
-                "pageSize": 25,
                 "total": 18,
-                "retention": {
-                  "jobEventDays": 14,
-                  "attemptHistoryDays": 14
-                },
                 "events": [
                   {
                     "id": {
                       "$type": "string"
                     },
                     "kind": "event",
-                    "recordId": {
-                      "$type": "uuid"
-                    },
+                    "type": "enqueued",
                     "jobId": {
                       "$ref": "purgeTargetJob"
                     },
                     "queue": "conformance-purge",
-                    "jobType": "conformance.purge",
-                    "occurredAt": {
-                      "$type": "timestamp"
-                    },
                     "attempt": null,
-                    "type": "enqueued",
                     "details": {
                       "state": "ready",
                       "run_at": {
@@ -1367,9 +1350,16 @@
                       "deadline_at": null,
                       "execution_timeout_ms": null
                     },
+                    "jobType": "conformance.purge",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
                     "workerId": null,
-                    "fenceToken": null,
                     "durationMs": null,
+                    "fenceToken": null,
+                    "occurredAt": {
+                      "$type": "timestamp"
+                    },
                     "errorMessage": null
                   },
                   {
@@ -1377,19 +1367,12 @@
                       "$type": "string"
                     },
                     "kind": "event",
-                    "recordId": {
-                      "$type": "uuid"
-                    },
+                    "type": "enqueued",
                     "jobId": {
                       "$ref": "cancelTargetJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.cancel-target",
-                    "occurredAt": {
-                      "$type": "timestamp"
-                    },
                     "attempt": null,
-                    "type": "enqueued",
                     "details": {
                       "state": "ready",
                       "run_at": {
@@ -1399,9 +1382,16 @@
                       "deadline_at": null,
                       "execution_timeout_ms": null
                     },
+                    "jobType": "conformance.cancel-target",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
                     "workerId": null,
-                    "fenceToken": null,
                     "durationMs": null,
+                    "fenceToken": null,
+                    "occurredAt": {
+                      "$type": "timestamp"
+                    },
                     "errorMessage": null
                   },
                   {
@@ -1409,19 +1399,12 @@
                       "$type": "string"
                     },
                     "kind": "event",
-                    "recordId": {
-                      "$type": "uuid"
-                    },
+                    "type": "enqueued",
                     "jobId": {
                       "$ref": "scheduledJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.scheduled",
-                    "occurredAt": {
-                      "$type": "timestamp"
-                    },
                     "attempt": null,
-                    "type": "enqueued",
                     "details": {
                       "state": "scheduled",
                       "run_at": {
@@ -1431,9 +1414,16 @@
                       "deadline_at": null,
                       "execution_timeout_ms": null
                     },
+                    "jobType": "conformance.scheduled",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
                     "workerId": null,
-                    "fenceToken": null,
                     "durationMs": null,
+                    "fenceToken": null,
+                    "occurredAt": {
+                      "$type": "timestamp"
+                    },
                     "errorMessage": null
                   },
                   {
@@ -1441,19 +1431,12 @@
                       "$type": "string"
                     },
                     "kind": "event",
-                    "recordId": {
-                      "$type": "uuid"
-                    },
+                    "type": "enqueued",
                     "jobId": {
                       "$ref": "readyJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.ready",
-                    "occurredAt": {
-                      "$type": "timestamp"
-                    },
                     "attempt": null,
-                    "type": "enqueued",
                     "details": {
                       "state": "ready",
                       "run_at": {
@@ -1463,9 +1446,16 @@
                       "deadline_at": null,
                       "execution_timeout_ms": null
                     },
+                    "jobType": "conformance.ready",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
                     "workerId": null,
-                    "fenceToken": null,
                     "durationMs": null,
+                    "fenceToken": null,
+                    "occurredAt": {
+                      "$type": "timestamp"
+                    },
                     "errorMessage": null
                   },
                   {
@@ -1473,27 +1463,27 @@
                       "$type": "string"
                     },
                     "kind": "event",
-                    "recordId": {
-                      "$type": "uuid"
-                    },
+                    "type": "human_wait_created",
                     "jobId": {
                       "$ref": "humanJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.human",
-                    "occurredAt": {
-                      "$type": "timestamp"
-                    },
                     "attempt": 1,
-                    "type": "human_wait_created",
                     "details": {
                       "name": "review",
                       "fence_token": "4",
                       "context_bytes": 44
                     },
+                    "jobType": "conformance.human",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
                     "workerId": null,
-                    "fenceToken": null,
                     "durationMs": null,
+                    "fenceToken": null,
+                    "occurredAt": {
+                      "$type": "timestamp"
+                    },
                     "errorMessage": null
                   },
                   {
@@ -1501,19 +1491,12 @@
                       "$type": "string"
                     },
                     "kind": "event",
-                    "recordId": {
-                      "$type": "uuid"
-                    },
+                    "type": "claimed",
                     "jobId": {
                       "$ref": "humanJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.human",
-                    "occurredAt": {
-                      "$type": "timestamp"
-                    },
                     "attempt": 1,
-                    "type": "claimed",
                     "details": {
                       "worker_id": "conformance-worker",
                       "expires_at": {
@@ -1521,9 +1504,16 @@
                       },
                       "fence_token": "4"
                     },
+                    "jobType": "conformance.human",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
                     "workerId": null,
-                    "fenceToken": null,
                     "durationMs": null,
+                    "fenceToken": null,
+                    "occurredAt": {
+                      "$type": "timestamp"
+                    },
                     "errorMessage": null
                   },
                   {
@@ -1531,19 +1521,12 @@
                       "$type": "string"
                     },
                     "kind": "event",
-                    "recordId": {
-                      "$type": "uuid"
-                    },
+                    "type": "enqueued",
                     "jobId": {
                       "$ref": "humanJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.human",
-                    "occurredAt": {
-                      "$type": "timestamp"
-                    },
                     "attempt": null,
-                    "type": "enqueued",
                     "details": {
                       "state": "ready",
                       "run_at": {
@@ -1553,9 +1536,16 @@
                       "deadline_at": null,
                       "execution_timeout_ms": null
                     },
+                    "jobType": "conformance.human",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
                     "workerId": null,
-                    "fenceToken": null,
                     "durationMs": null,
+                    "fenceToken": null,
+                    "occurredAt": {
+                      "$type": "timestamp"
+                    },
                     "errorMessage": null
                   },
                   {
@@ -1563,26 +1553,26 @@
                       "$type": "string"
                     },
                     "kind": "event",
-                    "recordId": {
-                      "$type": "uuid"
-                    },
+                    "type": "signal_waiting",
                     "jobId": {
                       "$ref": "signalJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.signal",
-                    "occurredAt": {
-                      "$type": "timestamp"
-                    },
                     "attempt": 1,
-                    "type": "signal_waiting",
                     "details": {
                       "name": "approval",
                       "fence_token": "3"
                     },
+                    "jobType": "conformance.signal",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
                     "workerId": null,
-                    "fenceToken": null,
                     "durationMs": null,
+                    "fenceToken": null,
+                    "occurredAt": {
+                      "$type": "timestamp"
+                    },
                     "errorMessage": null
                   },
                   {
@@ -1590,19 +1580,12 @@
                       "$type": "string"
                     },
                     "kind": "event",
-                    "recordId": {
-                      "$type": "uuid"
-                    },
+                    "type": "claimed",
                     "jobId": {
                       "$ref": "signalJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.signal",
-                    "occurredAt": {
-                      "$type": "timestamp"
-                    },
                     "attempt": 1,
-                    "type": "claimed",
                     "details": {
                       "worker_id": "conformance-worker",
                       "expires_at": {
@@ -1610,9 +1593,16 @@
                       },
                       "fence_token": "3"
                     },
+                    "jobType": "conformance.signal",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
                     "workerId": null,
-                    "fenceToken": null,
                     "durationMs": null,
+                    "fenceToken": null,
+                    "occurredAt": {
+                      "$type": "timestamp"
+                    },
                     "errorMessage": null
                   },
                   {
@@ -1620,19 +1610,12 @@
                       "$type": "string"
                     },
                     "kind": "event",
-                    "recordId": {
-                      "$type": "uuid"
-                    },
+                    "type": "enqueued",
                     "jobId": {
                       "$ref": "signalJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.signal",
-                    "occurredAt": {
-                      "$type": "timestamp"
-                    },
                     "attempt": null,
-                    "type": "enqueued",
                     "details": {
                       "state": "ready",
                       "run_at": {
@@ -1642,9 +1625,16 @@
                       "deadline_at": null,
                       "execution_timeout_ms": null
                     },
+                    "jobType": "conformance.signal",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
                     "workerId": null,
-                    "fenceToken": null,
                     "durationMs": null,
+                    "fenceToken": null,
+                    "occurredAt": {
+                      "$type": "timestamp"
+                    },
                     "errorMessage": null
                   },
                   {
@@ -1652,28 +1642,28 @@
                       "$type": "string"
                     },
                     "kind": "event",
-                    "recordId": {
-                      "$type": "uuid"
-                    },
+                    "type": "failed",
                     "jobId": {
                       "$ref": "failedJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.fail",
-                    "occurredAt": {
-                      "$type": "timestamp"
-                    },
                     "attempt": 1,
-                    "type": "failed",
                     "details": {
                       "error": {
                         "name": "Error",
                         "message": "conformance.fail failed"
                       }
                     },
+                    "jobType": "conformance.fail",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
                     "workerId": null,
-                    "fenceToken": null,
                     "durationMs": null,
+                    "fenceToken": null,
+                    "occurredAt": {
+                      "$type": "timestamp"
+                    },
                     "errorMessage": null
                   },
                   {
@@ -1681,24 +1671,24 @@
                       "$type": "string"
                     },
                     "kind": "attempt",
-                    "recordId": {
-                      "$type": "uuid"
-                    },
+                    "type": "failed",
                     "jobId": {
                       "$ref": "failedJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.fail",
-                    "occurredAt": {
-                      "$type": "timestamp"
-                    },
                     "attempt": 1,
-                    "type": "failed",
                     "details": null,
+                    "jobType": "conformance.fail",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
                     "workerId": "conformance-worker",
-                    "fenceToken": "2",
                     "durationMs": {
                       "$type": "integer"
+                    },
+                    "fenceToken": "2",
+                    "occurredAt": {
+                      "$type": "timestamp"
                     },
                     "errorMessage": "conformance.fail failed"
                   },
@@ -1707,19 +1697,12 @@
                       "$type": "string"
                     },
                     "kind": "event",
-                    "recordId": {
-                      "$type": "uuid"
-                    },
+                    "type": "claimed",
                     "jobId": {
                       "$ref": "failedJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.fail",
-                    "occurredAt": {
-                      "$type": "timestamp"
-                    },
                     "attempt": 1,
-                    "type": "claimed",
                     "details": {
                       "worker_id": "conformance-worker",
                       "expires_at": {
@@ -1727,9 +1710,16 @@
                       },
                       "fence_token": "2"
                     },
+                    "jobType": "conformance.fail",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
                     "workerId": null,
-                    "fenceToken": null,
                     "durationMs": null,
+                    "fenceToken": null,
+                    "occurredAt": {
+                      "$type": "timestamp"
+                    },
                     "errorMessage": null
                   },
                   {
@@ -1737,19 +1727,12 @@
                       "$type": "string"
                     },
                     "kind": "event",
-                    "recordId": {
-                      "$type": "uuid"
-                    },
+                    "type": "enqueued",
                     "jobId": {
                       "$ref": "failedJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.fail",
-                    "occurredAt": {
-                      "$type": "timestamp"
-                    },
                     "attempt": null,
-                    "type": "enqueued",
                     "details": {
                       "state": "ready",
                       "run_at": {
@@ -1759,9 +1742,16 @@
                       "deadline_at": null,
                       "execution_timeout_ms": null
                     },
+                    "jobType": "conformance.fail",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
                     "workerId": null,
-                    "fenceToken": null,
                     "durationMs": null,
+                    "fenceToken": null,
+                    "occurredAt": {
+                      "$type": "timestamp"
+                    },
                     "errorMessage": null
                   },
                   {
@@ -1769,25 +1759,25 @@
                       "$type": "string"
                     },
                     "kind": "event",
-                    "recordId": {
-                      "$type": "uuid"
-                    },
+                    "type": "succeeded",
                     "jobId": {
                       "$ref": "succeededJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.succeed",
-                    "occurredAt": {
-                      "$type": "timestamp"
-                    },
                     "attempt": 1,
-                    "type": "succeeded",
                     "details": {
                       "fence_token": "1"
                     },
+                    "jobType": "conformance.succeed",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
                     "workerId": null,
-                    "fenceToken": null,
                     "durationMs": null,
+                    "fenceToken": null,
+                    "occurredAt": {
+                      "$type": "timestamp"
+                    },
                     "errorMessage": null
                   },
                   {
@@ -1795,24 +1785,24 @@
                       "$type": "string"
                     },
                     "kind": "attempt",
-                    "recordId": {
-                      "$type": "uuid"
-                    },
+                    "type": "succeeded",
                     "jobId": {
                       "$ref": "succeededJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.succeed",
-                    "occurredAt": {
-                      "$type": "timestamp"
-                    },
                     "attempt": 1,
-                    "type": "succeeded",
                     "details": null,
+                    "jobType": "conformance.succeed",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
                     "workerId": "conformance-worker",
-                    "fenceToken": "1",
                     "durationMs": {
                       "$type": "integer"
+                    },
+                    "fenceToken": "1",
+                    "occurredAt": {
+                      "$type": "timestamp"
                     },
                     "errorMessage": null
                   },
@@ -1821,19 +1811,12 @@
                       "$type": "string"
                     },
                     "kind": "event",
-                    "recordId": {
-                      "$type": "uuid"
-                    },
+                    "type": "claimed",
                     "jobId": {
                       "$ref": "succeededJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.succeed",
-                    "occurredAt": {
-                      "$type": "timestamp"
-                    },
                     "attempt": 1,
-                    "type": "claimed",
                     "details": {
                       "worker_id": "conformance-worker",
                       "expires_at": {
@@ -1841,9 +1824,16 @@
                       },
                       "fence_token": "1"
                     },
+                    "jobType": "conformance.succeed",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
                     "workerId": null,
-                    "fenceToken": null,
                     "durationMs": null,
+                    "fenceToken": null,
+                    "occurredAt": {
+                      "$type": "timestamp"
+                    },
                     "errorMessage": null
                   },
                   {
@@ -1851,19 +1841,12 @@
                       "$type": "string"
                     },
                     "kind": "event",
-                    "recordId": {
-                      "$type": "uuid"
-                    },
+                    "type": "enqueued",
                     "jobId": {
                       "$ref": "succeededJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.succeed",
-                    "occurredAt": {
-                      "$type": "timestamp"
-                    },
                     "attempt": null,
-                    "type": "enqueued",
                     "details": {
                       "state": "ready",
                       "run_at": {
@@ -1873,12 +1856,29 @@
                       "deadline_at": null,
                       "execution_timeout_ms": null
                     },
+                    "jobType": "conformance.succeed",
+                    "recordId": {
+                      "$type": "uuid"
+                    },
                     "workerId": null,
-                    "fenceToken": null,
                     "durationMs": null,
+                    "fenceToken": null,
+                    "occurredAt": {
+                      "$type": "timestamp"
+                    },
                     "errorMessage": null
                   }
-                ]
+                ],
+                "window": "1h",
+                "pageSize": 25,
+                "retention": {
+                  "jobEventDays": 14,
+                  "attemptHistoryDays": 14
+                },
+                "capturedAt": {
+                  "$type": "timestamp"
+                },
+                "windowSeconds": 3600
               }
             }
           },
@@ -1908,19 +1908,13 @@
                   "$ref": "eventDetailId"
                 },
                 "kind": "event",
-                "recordId": {
-                  "$type": "uuid"
-                },
+                "type": "enqueued",
+                "error": null,
                 "jobId": {
                   "$ref": "purgeTargetJob"
                 },
                 "queue": "conformance-purge",
-                "jobType": "conformance.purge",
-                "occurredAt": {
-                  "$type": "timestamp"
-                },
                 "attempt": null,
-                "type": "enqueued",
                 "details": {
                   "state": "ready",
                   "run_at": {
@@ -1930,13 +1924,19 @@
                   "deadline_at": null,
                   "execution_timeout_ms": null
                 },
+                "jobType": "conformance.purge",
+                "recordId": {
+                  "$type": "uuid"
+                },
                 "workerId": null,
-                "fenceToken": null,
-                "startedAt": null,
                 "claimedAt": null,
-                "finishedAt": null,
+                "startedAt": null,
                 "durationMs": null,
-                "error": null,
+                "fenceToken": null,
+                "finishedAt": null,
+                "occurredAt": {
+                  "$type": "timestamp"
+                },
                 "errorMessage": null
               }
             }
@@ -1950,85 +1950,85 @@
             "status": 200,
             "body": {
               "json": {
+                "schedules": [
+                  {
+                    "cron": "0 3 * * *",
+                    "kind": "user",
+                    "name": "nightly-report",
+                    "type": "conformance.report",
+                    "queue": "conformance",
+                    "active": true,
+                    "enabled": true,
+                    "identity": {
+                      "kind": "user",
+                      "name": "nightly-report",
+                      "namespace": "conformance"
+                    },
+                    "priority": 0,
+                    "revision": "1",
+                    "namespace": "conformance",
+                    "updatedAt": {
+                      "$type": "timestamp"
+                    },
+                    "lastFiredAt": null,
+                    "evaluatorCount": 1,
+                    "occurrenceCount": 0
+                  }
+                ],
                 "capturedAt": {
                   "$type": "timestamp"
                 },
-                "schedules": [
-                  {
-                    "kind": "user",
-                    "identity": {
-                      "kind": "user",
-                      "namespace": "conformance",
-                      "name": "nightly-report"
-                    },
-                    "namespace": "conformance",
-                    "name": "nightly-report",
-                    "cron": "0 3 * * *",
-                    "queue": "conformance",
-                    "type": "conformance.report",
-                    "priority": 0,
-                    "enabled": true,
-                    "active": true,
-                    "revision": "1",
-                    "updatedAt": {
-                      "$type": "timestamp"
-                    },
-                    "occurrenceCount": 0,
-                    "lastFiredAt": null,
-                    "evaluatorCount": 1
-                  }
-                ],
                 "maintenance": {
-                  "cadences": {
-                    "tickIntervalMs": 1000
-                  },
-                  "policy": {
-                    "timezone": "UTC",
-                    "partitionPreparationIntervalMs": 21600000,
-                    "terminalCleanupIntervalMs": 300000,
-                    "historyRetentionLocalTime": "03:00",
-                    "updatedAt": {
-                      "$type": "timestamp"
-                    }
-                  },
                   "tasks": [
                     {
+                      "due": {
+                        "$type": "boolean"
+                      },
                       "task": "history_partitions",
+                      "incomplete": false,
                       "lastStartedAt": null,
-                      "lastCompletedAt": null,
+                      "lastCompletedAt": null
+                    },
+                    {
                       "due": {
                         "$type": "boolean"
                       },
-                      "incomplete": false
-                    },
-                    {
                       "task": "history_retention",
+                      "incomplete": false,
                       "lastStartedAt": null,
-                      "lastCompletedAt": null,
+                      "lastCompletedAt": null
+                    },
+                    {
                       "due": {
                         "$type": "boolean"
                       },
-                      "incomplete": false
-                    },
-                    {
                       "task": "terminal_storage",
+                      "incomplete": false,
                       "lastStartedAt": null,
-                      "lastCompletedAt": null,
-                      "due": {
-                        "$type": "boolean"
-                      },
-                      "incomplete": false
+                      "lastCompletedAt": null
                     },
                     {
-                      "task": "tick",
-                      "lastStartedAt": null,
-                      "lastCompletedAt": null,
                       "due": {
                         "$type": "boolean"
                       },
-                      "incomplete": false
+                      "task": "tick",
+                      "incomplete": false,
+                      "lastStartedAt": null,
+                      "lastCompletedAt": null
                     }
-                  ]
+                  ],
+                  "policy": {
+                    "timezone": "UTC",
+                    "updatedAt": {
+                      "$type": "timestamp"
+                    },
+                    "historyRetentionLocalTime": "03:00",
+                    "terminalCleanupIntervalMs": 300000,
+                    "partitionPreparationIntervalMs": 21600000
+                  },
+                  "cadences": {
+                    "tickIntervalMs": 1000
+                  }
                 }
               }
             }
@@ -2045,39 +2045,39 @@
             "status": 200,
             "body": {
               "json": {
-                "capturedAt": {
-                  "$type": "timestamp"
-                },
                 "queues": [
                   {
                     "queue": "conformance",
-                    "paused": false,
-                    "scheduled": 3,
                     "ready": 2,
                     "active": 0,
-                    "succeeded": 1,
                     "failed": 1,
+                    "paused": false,
                     "canceled": 0,
-                    "terminalCountsApproximate": false,
+                    "scheduled": 3,
+                    "succeeded": 1,
+                    "rateLimitPolicy": null,
                     "concurrencyPolicy": null,
-                    "rateLimitPolicy": null
+                    "terminalCountsApproximate": false
                   },
                   {
                     "queue": "conformance-purge",
-                    "paused": false,
-                    "scheduled": 0,
                     "ready": 1,
                     "active": 0,
-                    "succeeded": 0,
                     "failed": 0,
+                    "paused": false,
                     "canceled": 0,
-                    "terminalCountsApproximate": false,
+                    "scheduled": 0,
+                    "succeeded": 0,
+                    "rateLimitPolicy": null,
                     "concurrencyPolicy": null,
-                    "rateLimitPolicy": null
+                    "terminalCountsApproximate": false
                   }
                 ],
-                "concurrencyPoliciesCapped": false,
-                "rateLimitPoliciesCapped": false
+                "capturedAt": {
+                  "$type": "timestamp"
+                },
+                "rateLimitPoliciesCapped": false,
+                "concurrencyPoliciesCapped": false
               }
             }
           }
@@ -2094,11 +2094,159 @@
             "status": 200,
             "body": {
               "json": {
-                "capturedAt": {
-                  "$type": "timestamp"
+                "kpis": {
+                  "drain": {
+                    "netPerMinute": -0.1,
+                    "enqueuedPerMinute": 0.13333333333333333,
+                    "completedPerMinute": 0.03333333333333333
+                  },
+                  "lease": {
+                    "active": 0,
+                    "expired": 0,
+                    "recovered": 0,
+                    "expiringSoon": 0
+                  },
+                  "retry": {
+                    "backoff": 0,
+                    "buckets": [
+                      {
+                        "count": 0,
+                        "upperBoundMs": 60000
+                      },
+                      {
+                        "count": 0,
+                        "upperBoundMs": 300000
+                      },
+                      {
+                        "count": 0,
+                        "upperBoundMs": 900000
+                      },
+                      {
+                        "count": 0,
+                        "upperBoundMs": 3600000
+                      },
+                      {
+                        "count": 0,
+                        "upperBoundMs": null
+                      }
+                    ],
+                    "dueSoon": 0
+                  },
+                  "backlog": {
+                    "ready": 3,
+                    "oldestReadyMs": {
+                      "$type": "string"
+                    }
+                  },
+                  "children": {
+                    "capped": false,
+                    "failedParents": 0,
+                    "waitingParents": 0,
+                    "canceledParents": 0,
+                    "pendingChildren": 0,
+                    "unjoinedResults": 0
+                  },
+                  "deadline": {
+                    "overdue": 0,
+                    "pending": 2,
+                    "earliestAt": {
+                      "$type": "timestamp"
+                    },
+                    "activeTimeouts": 0,
+                    "dueWithinMinute": 0,
+                    "overdueTimeouts": 0
+                  },
+                  "errorRate": {
+                    "delta": 0.5,
+                    "current": 0.5,
+                    "previous": 0
+                  },
+                  "queueWait": {
+                    "p50Ms": {
+                      "$type": "number"
+                    },
+                    "p95Ms": {
+                      "$type": "number"
+                    },
+                    "p99Ms": {
+                      "$type": "number"
+                    }
+                  },
+                  "dependencies": {
+                    "capped": false,
+                    "blockedJobs": 0,
+                    "pendingEdges": 0,
+                    "failedResolutions": 0,
+                    "retentionPruneStarved": false
+                  },
+                  "externalWaits": {
+                    "capped": false,
+                    "overdue": 0,
+                    "pendingSignals": 1,
+                    "oldestPendingAgeMs": {
+                      "$type": "number"
+                    },
+                    "rejectedDeliveries": 0,
+                    "pendingHumanDecisions": 1
+                  }
                 },
-                "window": "1h",
-                "windowSeconds": 3600,
+                "queues": [
+                  {
+                    "queue": "conformance",
+                    "ready": 2,
+                    "active": 0,
+                    "paused": false,
+                    "dueSoon": 0,
+                    "retrying": 0,
+                    "oldestReadyMs": {
+                      "$type": "string"
+                    },
+                    "priorityBacklog": [
+                      {
+                        "ready": 1,
+                        "priority": 5,
+                        "oldestReadyMs": {
+                          "$type": "string"
+                        }
+                      },
+                      {
+                        "ready": 1,
+                        "priority": 0,
+                        "oldestReadyMs": {
+                          "$type": "string"
+                        }
+                      }
+                    ],
+                    "rateLimitPolicy": null,
+                    "concurrencyPolicy": null,
+                    "enqueuedPerMinute": 0.11666666666666667,
+                    "completedPerMinute": 0.03333333333333333
+                  },
+                  {
+                    "queue": "conformance-purge",
+                    "ready": 1,
+                    "active": 0,
+                    "paused": false,
+                    "dueSoon": 0,
+                    "retrying": 0,
+                    "oldestReadyMs": {
+                      "$type": "string"
+                    },
+                    "priorityBacklog": [
+                      {
+                        "ready": 1,
+                        "priority": 0,
+                        "oldestReadyMs": {
+                          "$type": "string"
+                        }
+                      }
+                    ],
+                    "rateLimitPolicy": null,
+                    "concurrencyPolicy": null,
+                    "enqueuedPerMinute": 0.016666666666666666,
+                    "completedPerMinute": 0
+                  }
+                ],
                 "status": {
                   "level": "degraded",
                   "reasons": [
@@ -2112,107 +2260,17 @@
                     }
                   ]
                 },
-                "pausedQueues": [],
-                "kpis": {
-                  "drain": {
-                    "enqueuedPerMinute": 0.13333333333333333,
-                    "completedPerMinute": 0.03333333333333333,
-                    "netPerMinute": -0.1
-                  },
-                  "backlog": {
-                    "ready": 3,
-                    "oldestReadyMs": {
-                      "$type": "string"
-                    }
-                  },
-                  "errorRate": {
-                    "current": 0.5,
-                    "previous": 0,
-                    "delta": 0.5
-                  },
-                  "queueWait": {
-                    "p50Ms": {
-                      "$type": "number"
-                    },
-                    "p95Ms": {
-                      "$type": "number"
-                    },
-                    "p99Ms": {
-                      "$type": "number"
-                    }
-                  },
-                  "retry": {
-                    "backoff": 0,
-                    "dueSoon": 0,
-                    "buckets": [
-                      {
-                        "upperBoundMs": 60000,
-                        "count": 0
-                      },
-                      {
-                        "upperBoundMs": 300000,
-                        "count": 0
-                      },
-                      {
-                        "upperBoundMs": 900000,
-                        "count": 0
-                      },
-                      {
-                        "upperBoundMs": 3600000,
-                        "count": 0
-                      },
-                      {
-                        "upperBoundMs": null,
-                        "count": 0
-                      }
-                    ]
-                  },
-                  "lease": {
-                    "active": 0,
-                    "expired": 0,
-                    "expiringSoon": 0,
-                    "recovered": 0
-                  },
-                  "dependencies": {
-                    "blockedJobs": 0,
-                    "pendingEdges": 0,
-                    "failedResolutions": 0,
-                    "retentionPruneStarved": false,
-                    "capped": false
-                  },
-                  "children": {
-                    "waitingParents": 0,
-                    "pendingChildren": 0,
-                    "unjoinedResults": 0,
-                    "failedParents": 0,
-                    "canceledParents": 0,
-                    "capped": false
-                  },
-                  "externalWaits": {
-                    "pendingSignals": 1,
-                    "pendingHumanDecisions": 1,
-                    "overdue": 0,
-                    "oldestPendingAgeMs": {
-                      "$type": "number"
-                    },
-                    "rejectedDeliveries": 0,
-                    "capped": false
-                  },
-                  "deadline": {
-                    "pending": 2,
-                    "overdue": 0,
-                    "dueWithinMinute": 0,
-                    "earliestAt": {
-                      "$type": "timestamp"
-                    },
-                    "activeTimeouts": 0,
-                    "overdueTimeouts": 0
-                  }
-                },
+                "window": "1h",
                 "outcomes": [
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2220,22 +2278,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2243,22 +2301,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2266,22 +2324,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2289,22 +2347,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2312,22 +2370,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2335,22 +2393,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2358,22 +2416,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2381,22 +2439,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2404,22 +2462,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2427,22 +2485,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2450,22 +2508,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2473,22 +2531,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2496,22 +2554,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2519,22 +2577,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2542,22 +2600,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2565,22 +2623,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2588,22 +2646,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2611,22 +2669,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2634,22 +2692,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2657,22 +2715,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2680,22 +2738,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2703,22 +2761,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2726,22 +2784,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2749,22 +2807,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2772,22 +2830,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2795,22 +2853,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2818,22 +2876,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2841,22 +2899,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2864,22 +2922,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2887,22 +2945,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2910,22 +2968,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2933,22 +2991,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2956,22 +3014,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -2979,22 +3037,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3002,22 +3060,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3025,22 +3083,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3048,22 +3106,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3071,22 +3129,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3094,22 +3152,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3117,22 +3175,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3140,22 +3198,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3163,22 +3221,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3186,22 +3244,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3209,22 +3267,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3232,22 +3290,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3255,22 +3313,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3278,22 +3336,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3301,22 +3359,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3324,22 +3382,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3347,22 +3405,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3370,22 +3428,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3393,22 +3451,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3416,22 +3474,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3439,22 +3497,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3462,22 +3520,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3485,22 +3543,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3508,22 +3566,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3531,22 +3589,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3554,22 +3612,22 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
-                      "$type": "integer"
-                    },
-                    "canceled": {
                       "$type": "integer"
                     }
                   },
                   {
-                    "bucketStart": {
-                      "$type": "timestamp"
+                    "retry": {
+                      "$type": "integer"
+                    },
+                    "failed": {
+                      "$type": "integer"
+                    },
+                    "canceled": {
+                      "$type": "integer"
                     },
                     "enqueued": {
                       "$type": "integer"
@@ -3577,119 +3635,310 @@
                     "succeeded": {
                       "$type": "integer"
                     },
-                    "failed": {
-                      "$type": "integer"
-                    },
-                    "retry": {
-                      "$type": "integer"
+                    "bucketStart": {
+                      "$type": "timestamp"
                     },
                     "leaseExpired": {
                       "$type": "integer"
-                    },
-                    "canceled": {
-                      "$type": "integer"
-                    }
-                  }
-                ],
-                "queues": [
-                  {
-                    "queue": "conformance",
-                    "paused": false,
-                    "ready": 2,
-                    "oldestReadyMs": {
-                      "$type": "string"
-                    },
-                    "priorityBacklog": [
-                      {
-                        "priority": 5,
-                        "ready": 1,
-                        "oldestReadyMs": {
-                          "$type": "string"
-                        }
-                      },
-                      {
-                        "priority": 0,
-                        "ready": 1,
-                        "oldestReadyMs": {
-                          "$type": "string"
-                        }
-                      }
-                    ],
-                    "dueSoon": 0,
-                    "active": 0,
-                    "retrying": 0,
-                    "enqueuedPerMinute": 0.11666666666666667,
-                    "completedPerMinute": 0.03333333333333333,
-                    "concurrencyPolicy": null,
-                    "rateLimitPolicy": null
-                  },
-                  {
-                    "queue": "conformance-purge",
-                    "paused": false,
-                    "ready": 1,
-                    "oldestReadyMs": {
-                      "$type": "string"
-                    },
-                    "priorityBacklog": [
-                      {
-                        "priority": 0,
-                        "ready": 1,
-                        "oldestReadyMs": {
-                          "$type": "string"
-                        }
-                      }
-                    ],
-                    "dueSoon": 0,
-                    "active": 0,
-                    "retrying": 0,
-                    "enqueuedPerMinute": 0.016666666666666666,
-                    "completedPerMinute": 0,
-                    "concurrencyPolicy": null,
-                    "rateLimitPolicy": null
-                  }
-                ],
-                "concurrencyPoliciesCapped": false,
-                "rateLimitPoliciesCapped": false,
-                "retryStorm": {
-                  "buckets": [
-                    {
-                      "upperBoundMs": 60000,
-                      "count": 0
-                    },
-                    {
-                      "upperBoundMs": 300000,
-                      "count": 0
-                    },
-                    {
-                      "upperBoundMs": 900000,
-                      "count": 0
-                    },
-                    {
-                      "upperBoundMs": 3600000,
-                      "count": 0
-                    },
-                    {
-                      "upperBoundMs": null,
-                      "count": 0
-                    }
-                  ],
-                  "topTypes": []
-                },
-                "failingTypes": [
-                  {
-                    "queue": "conformance",
-                    "type": "conformance.fail",
-                    "attempts": 1,
-                    "errorRate": 1,
-                    "terminalFailures": 1,
-                    "lastError": "conformance.fail failed",
-                    "lastSeenAt": {
-                      "$type": "timestamp"
                     }
                   }
                 ],
                 "integrity": {
-                  "dueButUnpromoted": 0,
+                  "storage": {
+                    "rollup": {
+                      "lagMs": {
+                        "$type": "number"
+                      },
+                      "buckets": 0,
+                      "stalled": true,
+                      "lastRunAt": null,
+                      "newestBucketAt": null,
+                      "oldestBucketAt": null,
+                      "rolledUpThrough": {
+                        "$type": "timestamp"
+                      }
+                    },
+                    "relations": [
+                      {
+                        "rows": {
+                          "$type": "integer"
+                        },
+                        "deadRows": {
+                          "$type": "integer"
+                        },
+                        "relation": "job_event",
+                        "indexBytes": {
+                          "$type": "integer"
+                        },
+                        "partitions": 5,
+                        "tableBytes": {
+                          "$type": "integer"
+                        },
+                        "totalBytes": {
+                          "$type": "integer"
+                        },
+                        "lastVacuumAt": null
+                      },
+                      {
+                        "rows": {
+                          "$type": "integer"
+                        },
+                        "deadRows": {
+                          "$type": "integer"
+                        },
+                        "relation": "attempt_history",
+                        "indexBytes": {
+                          "$type": "integer"
+                        },
+                        "partitions": 5,
+                        "tableBytes": {
+                          "$type": "integer"
+                        },
+                        "totalBytes": {
+                          "$type": "integer"
+                        },
+                        "lastVacuumAt": null
+                      },
+                      {
+                        "rows": {
+                          "$type": "integer"
+                        },
+                        "deadRows": {
+                          "$type": "integer"
+                        },
+                        "relation": "job_runtime",
+                        "indexBytes": {
+                          "$type": "integer"
+                        },
+                        "partitions": 0,
+                        "tableBytes": {
+                          "$type": "integer"
+                        },
+                        "totalBytes": {
+                          "$type": "integer"
+                        },
+                        "lastVacuumAt": null
+                      },
+                      {
+                        "rows": {
+                          "$type": "integer"
+                        },
+                        "deadRows": {
+                          "$type": "integer"
+                        },
+                        "relation": "job_outcome",
+                        "indexBytes": {
+                          "$type": "integer"
+                        },
+                        "partitions": 0,
+                        "tableBytes": {
+                          "$type": "integer"
+                        },
+                        "totalBytes": {
+                          "$type": "integer"
+                        },
+                        "lastVacuumAt": null
+                      },
+                      {
+                        "rows": {
+                          "$type": "integer"
+                        },
+                        "deadRows": {
+                          "$type": "integer"
+                        },
+                        "relation": "job_query",
+                        "indexBytes": {
+                          "$type": "integer"
+                        },
+                        "partitions": 0,
+                        "tableBytes": {
+                          "$type": "integer"
+                        },
+                        "totalBytes": {
+                          "$type": "integer"
+                        },
+                        "lastVacuumAt": null
+                      },
+                      {
+                        "rows": {
+                          "$type": "integer"
+                        },
+                        "deadRows": {
+                          "$type": "integer"
+                        },
+                        "relation": "job",
+                        "indexBytes": {
+                          "$type": "integer"
+                        },
+                        "partitions": 0,
+                        "tableBytes": {
+                          "$type": "integer"
+                        },
+                        "totalBytes": {
+                          "$type": "integer"
+                        },
+                        "lastVacuumAt": null
+                      },
+                      {
+                        "rows": {
+                          "$type": "integer"
+                        },
+                        "deadRows": {
+                          "$type": "integer"
+                        },
+                        "relation": "schedule_occurrence",
+                        "indexBytes": {
+                          "$type": "integer"
+                        },
+                        "partitions": 0,
+                        "tableBytes": {
+                          "$type": "integer"
+                        },
+                        "totalBytes": {
+                          "$type": "integer"
+                        },
+                        "lastVacuumAt": null
+                      },
+                      {
+                        "rows": {
+                          "$type": "integer"
+                        },
+                        "deadRows": {
+                          "$type": "integer"
+                        },
+                        "relation": "job_stat_bucket",
+                        "indexBytes": {
+                          "$type": "integer"
+                        },
+                        "partitions": 0,
+                        "tableBytes": {
+                          "$type": "integer"
+                        },
+                        "totalBytes": {
+                          "$type": "integer"
+                        },
+                        "lastVacuumAt": null
+                      },
+                      {
+                        "rows": {
+                          "$type": "integer"
+                        },
+                        "deadRows": {
+                          "$type": "integer"
+                        },
+                        "relation": "job_stat_bucket_hour",
+                        "indexBytes": {
+                          "$type": "integer"
+                        },
+                        "partitions": 0,
+                        "tableBytes": {
+                          "$type": "integer"
+                        },
+                        "totalBytes": {
+                          "$type": "integer"
+                        },
+                        "lastVacuumAt": null
+                      },
+                      {
+                        "rows": {
+                          "$type": "integer"
+                        },
+                        "deadRows": {
+                          "$type": "integer"
+                        },
+                        "relation": "job_stat_bucket_day",
+                        "indexBytes": {
+                          "$type": "integer"
+                        },
+                        "partitions": 0,
+                        "tableBytes": {
+                          "$type": "integer"
+                        },
+                        "totalBytes": {
+                          "$type": "integer"
+                        },
+                        "lastVacuumAt": null
+                      }
+                    ],
+                    "totalBytes": {
+                      "$type": "integer"
+                    }
+                  },
+                  "retention": {
+                    "maxLagMs": null,
+                    "categories": [
+                      {
+                        "lagMs": null,
+                        "category": "jobIdentity",
+                        "retentionDays": 14,
+                        "oldestRetainedAt": {
+                          "$type": "timestamp"
+                        },
+                        "prunedByPartition": false
+                      },
+                      {
+                        "lagMs": null,
+                        "category": "terminalOutcome",
+                        "retentionDays": 14,
+                        "oldestRetainedAt": {
+                          "$type": "timestamp"
+                        },
+                        "prunedByPartition": false
+                      },
+                      {
+                        "lagMs": 0,
+                        "category": "jobEvents",
+                        "retentionDays": 14,
+                        "oldestRetainedAt": {
+                          "$type": "timestamp"
+                        },
+                        "prunedByPartition": true
+                      },
+                      {
+                        "lagMs": 0,
+                        "category": "attemptHistory",
+                        "retentionDays": 14,
+                        "oldestRetainedAt": {
+                          "$type": "timestamp"
+                        },
+                        "prunedByPartition": true
+                      },
+                      {
+                        "lagMs": null,
+                        "category": "scheduleOccurrences",
+                        "retentionDays": 14,
+                        "oldestRetainedAt": null,
+                        "prunedByPartition": false
+                      },
+                      {
+                        "lagMs": null,
+                        "category": "statistics",
+                        "retentionDays": 14,
+                        "oldestRetainedAt": null,
+                        "prunedByPartition": false
+                      }
+                    ],
+                    "maxLagCategory": null,
+                    "policyUpdatedAt": {
+                      "$type": "timestamp"
+                    },
+                    "oldestRetainedAt": {
+                      "$type": "timestamp"
+                    },
+                    "defaultHistoryRows": {
+                      "jobEvents": 0,
+                      "attemptHistory": 0
+                    },
+                    "oldestRetainedCategory": "jobIdentity",
+                    "defaultHistoryRowsCapped": {
+                      "jobEvents": false,
+                      "attemptHistory": false
+                    },
+                    "eligibleHistoryPartitions": {
+                      "jobEvents": 0,
+                      "attemptHistory": 0
+                    }
+                  },
                   "partitions": [
                     {
                       "day": {
@@ -3733,303 +3982,54 @@
                     }
                   ],
                   "defaultEventRows": 0,
-                  "defaultAttemptRows": 0,
-                  "retention": {
-                    "policyUpdatedAt": {
+                  "dueButUnpromoted": 0,
+                  "defaultAttemptRows": 0
+                },
+                "capturedAt": {
+                  "$type": "timestamp"
+                },
+                "retryStorm": {
+                  "buckets": [
+                    {
+                      "count": 0,
+                      "upperBoundMs": 60000
+                    },
+                    {
+                      "count": 0,
+                      "upperBoundMs": 300000
+                    },
+                    {
+                      "count": 0,
+                      "upperBoundMs": 900000
+                    },
+                    {
+                      "count": 0,
+                      "upperBoundMs": 3600000
+                    },
+                    {
+                      "count": 0,
+                      "upperBoundMs": null
+                    }
+                  ],
+                  "topTypes": []
+                },
+                "failingTypes": [
+                  {
+                    "type": "conformance.fail",
+                    "queue": "conformance",
+                    "attempts": 1,
+                    "errorRate": 1,
+                    "lastError": "conformance.fail failed",
+                    "lastSeenAt": {
                       "$type": "timestamp"
                     },
-                    "categories": [
-                      {
-                        "category": "jobIdentity",
-                        "retentionDays": 14,
-                        "lagMs": null,
-                        "oldestRetainedAt": {
-                          "$type": "timestamp"
-                        },
-                        "prunedByPartition": false
-                      },
-                      {
-                        "category": "terminalOutcome",
-                        "retentionDays": 14,
-                        "lagMs": null,
-                        "oldestRetainedAt": {
-                          "$type": "timestamp"
-                        },
-                        "prunedByPartition": false
-                      },
-                      {
-                        "category": "jobEvents",
-                        "retentionDays": 14,
-                        "lagMs": 0,
-                        "oldestRetainedAt": {
-                          "$type": "timestamp"
-                        },
-                        "prunedByPartition": true
-                      },
-                      {
-                        "category": "attemptHistory",
-                        "retentionDays": 14,
-                        "lagMs": 0,
-                        "oldestRetainedAt": {
-                          "$type": "timestamp"
-                        },
-                        "prunedByPartition": true
-                      },
-                      {
-                        "category": "scheduleOccurrences",
-                        "retentionDays": 14,
-                        "lagMs": null,
-                        "oldestRetainedAt": null,
-                        "prunedByPartition": false
-                      },
-                      {
-                        "category": "statistics",
-                        "retentionDays": 14,
-                        "lagMs": null,
-                        "oldestRetainedAt": null,
-                        "prunedByPartition": false
-                      }
-                    ],
-                    "maxLagMs": null,
-                    "maxLagCategory": null,
-                    "oldestRetainedAt": {
-                      "$type": "timestamp"
-                    },
-                    "oldestRetainedCategory": "jobIdentity",
-                    "eligibleHistoryPartitions": {
-                      "jobEvents": 0,
-                      "attemptHistory": 0
-                    },
-                    "defaultHistoryRows": {
-                      "jobEvents": 0,
-                      "attemptHistory": 0
-                    },
-                    "defaultHistoryRowsCapped": {
-                      "jobEvents": false,
-                      "attemptHistory": false
-                    }
-                  },
-                  "storage": {
-                    "rollup": {
-                      "rolledUpThrough": {
-                        "$type": "timestamp"
-                      },
-                      "lagMs": {
-                        "$type": "number"
-                      },
-                      "lastRunAt": null,
-                      "buckets": 0,
-                      "oldestBucketAt": null,
-                      "newestBucketAt": null,
-                      "stalled": true
-                    },
-                    "relations": [
-                      {
-                        "relation": "job_event",
-                        "totalBytes": {
-                          "$type": "integer"
-                        },
-                        "tableBytes": {
-                          "$type": "integer"
-                        },
-                        "indexBytes": {
-                          "$type": "integer"
-                        },
-                        "rows": {
-                          "$type": "integer"
-                        },
-                        "deadRows": {
-                          "$type": "integer"
-                        },
-                        "partitions": 5,
-                        "lastVacuumAt": null
-                      },
-                      {
-                        "relation": "attempt_history",
-                        "totalBytes": {
-                          "$type": "integer"
-                        },
-                        "tableBytes": {
-                          "$type": "integer"
-                        },
-                        "indexBytes": {
-                          "$type": "integer"
-                        },
-                        "rows": {
-                          "$type": "integer"
-                        },
-                        "deadRows": {
-                          "$type": "integer"
-                        },
-                        "partitions": 5,
-                        "lastVacuumAt": null
-                      },
-                      {
-                        "relation": "job_runtime",
-                        "totalBytes": {
-                          "$type": "integer"
-                        },
-                        "tableBytes": {
-                          "$type": "integer"
-                        },
-                        "indexBytes": {
-                          "$type": "integer"
-                        },
-                        "rows": {
-                          "$type": "integer"
-                        },
-                        "deadRows": {
-                          "$type": "integer"
-                        },
-                        "partitions": 0,
-                        "lastVacuumAt": null
-                      },
-                      {
-                        "relation": "job_outcome",
-                        "totalBytes": {
-                          "$type": "integer"
-                        },
-                        "tableBytes": {
-                          "$type": "integer"
-                        },
-                        "indexBytes": {
-                          "$type": "integer"
-                        },
-                        "rows": {
-                          "$type": "integer"
-                        },
-                        "deadRows": {
-                          "$type": "integer"
-                        },
-                        "partitions": 0,
-                        "lastVacuumAt": null
-                      },
-                      {
-                        "relation": "job_query",
-                        "totalBytes": {
-                          "$type": "integer"
-                        },
-                        "tableBytes": {
-                          "$type": "integer"
-                        },
-                        "indexBytes": {
-                          "$type": "integer"
-                        },
-                        "rows": {
-                          "$type": "integer"
-                        },
-                        "deadRows": {
-                          "$type": "integer"
-                        },
-                        "partitions": 0,
-                        "lastVacuumAt": null
-                      },
-                      {
-                        "relation": "job",
-                        "totalBytes": {
-                          "$type": "integer"
-                        },
-                        "tableBytes": {
-                          "$type": "integer"
-                        },
-                        "indexBytes": {
-                          "$type": "integer"
-                        },
-                        "rows": {
-                          "$type": "integer"
-                        },
-                        "deadRows": {
-                          "$type": "integer"
-                        },
-                        "partitions": 0,
-                        "lastVacuumAt": null
-                      },
-                      {
-                        "relation": "schedule_occurrence",
-                        "totalBytes": {
-                          "$type": "integer"
-                        },
-                        "tableBytes": {
-                          "$type": "integer"
-                        },
-                        "indexBytes": {
-                          "$type": "integer"
-                        },
-                        "rows": {
-                          "$type": "integer"
-                        },
-                        "deadRows": {
-                          "$type": "integer"
-                        },
-                        "partitions": 0,
-                        "lastVacuumAt": null
-                      },
-                      {
-                        "relation": "job_stat_bucket",
-                        "totalBytes": {
-                          "$type": "integer"
-                        },
-                        "tableBytes": {
-                          "$type": "integer"
-                        },
-                        "indexBytes": {
-                          "$type": "integer"
-                        },
-                        "rows": {
-                          "$type": "integer"
-                        },
-                        "deadRows": {
-                          "$type": "integer"
-                        },
-                        "partitions": 0,
-                        "lastVacuumAt": null
-                      },
-                      {
-                        "relation": "job_stat_bucket_hour",
-                        "totalBytes": {
-                          "$type": "integer"
-                        },
-                        "tableBytes": {
-                          "$type": "integer"
-                        },
-                        "indexBytes": {
-                          "$type": "integer"
-                        },
-                        "rows": {
-                          "$type": "integer"
-                        },
-                        "deadRows": {
-                          "$type": "integer"
-                        },
-                        "partitions": 0,
-                        "lastVacuumAt": null
-                      },
-                      {
-                        "relation": "job_stat_bucket_day",
-                        "totalBytes": {
-                          "$type": "integer"
-                        },
-                        "tableBytes": {
-                          "$type": "integer"
-                        },
-                        "indexBytes": {
-                          "$type": "integer"
-                        },
-                        "rows": {
-                          "$type": "integer"
-                        },
-                        "deadRows": {
-                          "$type": "integer"
-                        },
-                        "partitions": 0,
-                        "lastVacuumAt": null
-                      }
-                    ],
-                    "totalBytes": {
-                      "$type": "integer"
-                    }
+                    "terminalFailures": 1
                   }
-                }
+                ],
+                "pausedQueues": [],
+                "windowSeconds": 3600,
+                "rateLimitPoliciesCapped": false,
+                "concurrencyPoliciesCapped": false
               }
             }
           },
@@ -4061,43 +4061,43 @@
             "status": 200,
             "body": {
               "json": {
-                "capturedAt": {
-                  "$type": "timestamp"
-                },
-                "canManageWorkers": true,
                 "workers": [
                   {
                     "id": "conformance-worker",
+                    "pid": 4242,
+                    "paused": false,
                     "queues": [
                       "conformance"
                     ],
-                    "scheduleNamespaces": [
-                      "conformance"
-                    ],
-                    "hostname": "conformance-host",
-                    "pid": 4242,
-                    "activeJobs": 0,
-                    "concurrency": 2,
-                    "activeSlots": 0,
                     "draining": false,
-                    "completedAttempts": 2,
-                    "failedAttempts": 1,
-                    "averageExecutionMs": {
-                      "$type": "number"
-                    },
-                    "lastSeenAt": {
-                      "$type": "timestamp"
-                    },
+                    "hostname": "conformance-host",
                     "startedAt": {
                       "$type": "timestamp"
                     },
+                    "activeJobs": 0,
+                    "lastSeenAt": {
+                      "$type": "timestamp"
+                    },
                     "registered": true,
+                    "activeSlots": 0,
+                    "concurrency": 2,
+                    "failedAttempts": 1,
                     "lastHeartbeatAt": {
                       "$type": "timestamp"
                     },
-                    "paused": false
+                    "completedAttempts": 2,
+                    "averageExecutionMs": {
+                      "$type": "number"
+                    },
+                    "scheduleNamespaces": [
+                      "conformance"
+                    ]
                   }
-                ]
+                ],
+                "capturedAt": {
+                  "$type": "timestamp"
+                },
+                "canManageWorkers": true
               }
             }
           }
@@ -4110,100 +4110,34 @@
             "status": 200,
             "body": {
               "json": {
-                "capturedAt": {
-                  "$type": "timestamp"
-                },
+                "workers": [
+                  {
+                    "id": "conformance-worker",
+                    "queue": "conformance",
+                    "pollMs": 250,
+                    "queues": [
+                      "conformance"
+                    ],
+                    "leaseMs": 30000,
+                    "lastSeenAt": {
+                      "$type": "timestamp"
+                    },
+                    "concurrency": 2,
+                    "heartbeatMs": 10000,
+                    "registryIntervalMs": 5000,
+                    "maintenanceIntervalMs": 1000,
+                    "maintenanceTaskPollMs": 60000
+                  }
+                ],
                 "editable": true,
-                "maintenance": {
-                  "timezone": "UTC",
-                  "partitionPreparationIntervalMs": 21600000,
-                  "terminalCleanupIntervalMs": 300000,
-                  "historyRetentionLocalTime": "03:00",
-                  "statisticsRollupIntervalMs": 60000,
-                  "statisticsGroupLimit": 200,
-                  "statisticsRecomputeBuckets": 2,
-                  "provenance": {
-                    "timezone": {
-                      "source": "application",
-                      "applicationDefault": "UTC"
-                    },
-                    "partitionPreparationIntervalMs": {
-                      "source": "application",
-                      "applicationDefault": 21600000
-                    },
-                    "terminalCleanupIntervalMs": {
-                      "source": "application",
-                      "applicationDefault": 300000
-                    },
-                    "historyRetentionLocalTime": {
-                      "source": "application",
-                      "applicationDefault": "03:00"
-                    },
-                    "statisticsRollupIntervalMs": {
-                      "source": "application",
-                      "applicationDefault": 60000
-                    },
-                    "statisticsGroupLimit": {
-                      "source": "application",
-                      "applicationDefault": 200
-                    },
-                    "statisticsRecomputeBuckets": {
-                      "source": "application",
-                      "applicationDefault": 2
-                    }
-                  },
+                "retention": {
                   "updatedAt": {
                     "$type": "timestamp"
-                  }
-                },
-                "retention": {
-                  "jobIdentityRetentionDays": 14,
-                  "terminalOutcomeRetentionDays": 14,
-                  "jobEventRetentionDays": 14,
-                  "attemptHistoryRetentionDays": 14,
-                  "scheduleOccurrenceRetentionDays": 14,
-                  "statisticsRetentionDays": 14,
-                  "terminalJobPruneLimit": 1000,
-                  "historyPartitionsPerPass": 4,
-                  "defaultPartitionRowsPerPass": 10000,
-                  "occurrenceRowsPerPass": 10000,
-                  "statisticsRowsPerPass": 10000,
+                  },
                   "provenance": {
-                    "jobIdentityRetentionDays": {
-                      "source": "application",
-                      "applicationDefault": 14
-                    },
-                    "terminalOutcomeRetentionDays": {
-                      "source": "application",
-                      "applicationDefault": 14
-                    },
                     "jobEventRetentionDays": {
                       "source": "application",
                       "applicationDefault": 14
-                    },
-                    "attemptHistoryRetentionDays": {
-                      "source": "application",
-                      "applicationDefault": 14
-                    },
-                    "scheduleOccurrenceRetentionDays": {
-                      "source": "application",
-                      "applicationDefault": 14
-                    },
-                    "statisticsRetentionDays": {
-                      "source": "application",
-                      "applicationDefault": 14
-                    },
-                    "terminalJobPruneLimit": {
-                      "source": "application",
-                      "applicationDefault": 1000
-                    },
-                    "historyPartitionsPerPass": {
-                      "source": "application",
-                      "applicationDefault": 4
-                    },
-                    "defaultPartitionRowsPerPass": {
-                      "source": "application",
-                      "applicationDefault": 10000
                     },
                     "occurrenceRowsPerPass": {
                       "source": "application",
@@ -4212,11 +4146,96 @@
                     "statisticsRowsPerPass": {
                       "source": "application",
                       "applicationDefault": 10000
+                    },
+                    "terminalJobPruneLimit": {
+                      "source": "application",
+                      "applicationDefault": 1000
+                    },
+                    "statisticsRetentionDays": {
+                      "source": "application",
+                      "applicationDefault": 14
+                    },
+                    "historyPartitionsPerPass": {
+                      "source": "application",
+                      "applicationDefault": 4
+                    },
+                    "jobIdentityRetentionDays": {
+                      "source": "application",
+                      "applicationDefault": 14
+                    },
+                    "attemptHistoryRetentionDays": {
+                      "source": "application",
+                      "applicationDefault": 14
+                    },
+                    "defaultPartitionRowsPerPass": {
+                      "source": "application",
+                      "applicationDefault": 10000
+                    },
+                    "terminalOutcomeRetentionDays": {
+                      "source": "application",
+                      "applicationDefault": 14
+                    },
+                    "scheduleOccurrenceRetentionDays": {
+                      "source": "application",
+                      "applicationDefault": 14
                     }
                   },
+                  "jobEventRetentionDays": 14,
+                  "occurrenceRowsPerPass": 10000,
+                  "statisticsRowsPerPass": 10000,
+                  "terminalJobPruneLimit": 1000,
+                  "statisticsRetentionDays": 14,
+                  "historyPartitionsPerPass": 4,
+                  "jobIdentityRetentionDays": 14,
+                  "attemptHistoryRetentionDays": 14,
+                  "defaultPartitionRowsPerPass": 10000,
+                  "terminalOutcomeRetentionDays": 14,
+                  "scheduleOccurrenceRetentionDays": 14
+                },
+                "capturedAt": {
+                  "$type": "timestamp"
+                },
+                "maintenance": {
+                  "timezone": "UTC",
                   "updatedAt": {
                     "$type": "timestamp"
-                  }
+                  },
+                  "provenance": {
+                    "timezone": {
+                      "source": "application",
+                      "applicationDefault": "UTC"
+                    },
+                    "statisticsGroupLimit": {
+                      "source": "application",
+                      "applicationDefault": 200
+                    },
+                    "historyRetentionLocalTime": {
+                      "source": "application",
+                      "applicationDefault": "03:00"
+                    },
+                    "terminalCleanupIntervalMs": {
+                      "source": "application",
+                      "applicationDefault": 300000
+                    },
+                    "statisticsRecomputeBuckets": {
+                      "source": "application",
+                      "applicationDefault": 2
+                    },
+                    "statisticsRollupIntervalMs": {
+                      "source": "application",
+                      "applicationDefault": 60000
+                    },
+                    "partitionPreparationIntervalMs": {
+                      "source": "application",
+                      "applicationDefault": 21600000
+                    }
+                  },
+                  "statisticsGroupLimit": 200,
+                  "historyRetentionLocalTime": "03:00",
+                  "terminalCleanupIntervalMs": 300000,
+                  "statisticsRecomputeBuckets": 2,
+                  "statisticsRollupIntervalMs": 60000,
+                  "partitionPreparationIntervalMs": 21600000
                 },
                 "recommendationInputs": {
                   "reasons": [
@@ -4230,13 +4249,17 @@
                     }
                   ],
                   "statistics": {
-                    "rolledUpThrough": {
-                      "$type": "timestamp"
-                    },
                     "lagMs": {
                       "$type": "number"
                     },
-                    "lastRunAt": null
+                    "lastRunAt": null,
+                    "rolledUpThrough": {
+                      "$type": "timestamp"
+                    }
+                  },
+                  "enqueueRate": {
+                    "jobs": 8,
+                    "windowMs": 3600000
                   },
                   "defaultHistoryRows": {
                     "jobEvents": 0,
@@ -4245,31 +4268,8 @@
                   "defaultHistoryRowsCapped": {
                     "jobEvents": false,
                     "attemptHistory": false
-                  },
-                  "enqueueRate": {
-                    "jobs": 8,
-                    "windowMs": 3600000
                   }
-                },
-                "workers": [
-                  {
-                    "id": "conformance-worker",
-                    "queue": "conformance",
-                    "queues": [
-                      "conformance"
-                    ],
-                    "concurrency": 2,
-                    "leaseMs": 30000,
-                    "heartbeatMs": 10000,
-                    "pollMs": 250,
-                    "maintenanceIntervalMs": 1000,
-                    "maintenanceTaskPollMs": 60000,
-                    "registryIntervalMs": 5000,
-                    "lastSeenAt": {
-                      "$type": "timestamp"
-                    }
-                  }
-                ]
+                }
               }
             }
           },
@@ -4323,102 +4323,14 @@
             "status": 200,
             "body": {
               "json": {
-                "identity": {
-                  "id": {
-                    "$ref": "succeededJob"
-                  },
-                  "queue": "conformance",
-                  "type": "conformance.succeed",
-                  "priority": 0,
-                  "state": "succeeded",
-                  "createdAt": {
-                    "$type": "timestamp"
-                  },
-                  "retryPolicy": null,
-                  "maxAttempts": 25,
-                  "deadlineAt": null,
-                  "executionTimeoutMs": null,
-                  "concurrencyKey": null,
-                  "prerequisiteJobId": null,
-                  "prerequisiteJobIds": [],
-                  "dependencyPolicy": null,
-                  "dependencyReleasedAt": null,
-                  "blockedReason": null
-                },
-                "dependencyLineage": {
-                  "records": [],
-                  "truncated": false
-                },
-                "childLineage": {
-                  "records": [],
-                  "truncated": false
-                },
-                "redriveLineage": {
-                  "records": [],
-                  "truncated": false
-                },
-                "concurrencyPolicy": null,
-                "signalWait": null,
-                "canSignal": true,
-                "payload": {
-                  "step": 1
-                },
-                "progress": null,
-                "durability": null,
-                "current": {
-                  "runtime": null,
-                  "outcome": {
-                    "state": "succeeded",
-                    "attempt": 1,
-                    "finishedAt": {
-                      "$type": "timestamp"
-                    },
-                    "result": {
-                      "ok": true
-                    },
-                    "error": null
-                  },
-                  "result": {
-                    "ok": true
-                  },
-                  "error": null
-                },
-                "batchExecutions": [],
-                "attempts": [
-                  {
-                    "attempt": 1,
-                    "workerId": "conformance-worker",
-                    "outcome": "succeeded",
-                    "startedAt": {
-                      "$type": "timestamp"
-                    },
-                    "claimedAt": {
-                      "$type": "timestamp"
-                    },
-                    "finishedAt": {
-                      "$type": "timestamp"
-                    },
-                    "durationMs": {
-                      "$type": "number"
-                    },
-                    "executionMs": {
-                      "$type": "number"
-                    },
-                    "elapsedMs": {
-                      "$type": "number"
-                    },
-                    "error": null
-                  }
-                ],
-                "checkpoints": [],
                 "waits": [],
                 "events": [
                   {
                     "id": {
                       "$type": "uuid"
                     },
-                    "attempt": null,
                     "type": "enqueued",
+                    "attempt": null,
                     "details": {
                       "state": "ready",
                       "run_at": {
@@ -4436,8 +4348,8 @@
                     "id": {
                       "$type": "uuid"
                     },
-                    "attempt": 1,
                     "type": "claimed",
+                    "attempt": 1,
                     "details": {
                       "worker_id": "conformance-worker",
                       "expires_at": {
@@ -4453,8 +4365,8 @@
                     "id": {
                       "$type": "uuid"
                     },
-                    "attempt": 1,
                     "type": "succeeded",
+                    "attempt": 1,
                     "details": {
                       "fence_token": "1"
                     },
@@ -4462,7 +4374,95 @@
                       "$type": "timestamp"
                     }
                   }
-                ]
+                ],
+                "current": {
+                  "error": null,
+                  "result": {
+                    "ok": true
+                  },
+                  "outcome": {
+                    "error": null,
+                    "state": "succeeded",
+                    "result": {
+                      "ok": true
+                    },
+                    "attempt": 1,
+                    "finishedAt": {
+                      "$type": "timestamp"
+                    }
+                  },
+                  "runtime": null
+                },
+                "payload": {
+                  "step": 1
+                },
+                "attempts": [
+                  {
+                    "error": null,
+                    "attempt": 1,
+                    "outcome": "succeeded",
+                    "workerId": "conformance-worker",
+                    "claimedAt": {
+                      "$type": "timestamp"
+                    },
+                    "elapsedMs": {
+                      "$type": "number"
+                    },
+                    "startedAt": {
+                      "$type": "timestamp"
+                    },
+                    "durationMs": {
+                      "$type": "number"
+                    },
+                    "finishedAt": {
+                      "$type": "timestamp"
+                    },
+                    "executionMs": {
+                      "$type": "number"
+                    }
+                  }
+                ],
+                "identity": {
+                  "id": {
+                    "$ref": "succeededJob"
+                  },
+                  "type": "conformance.succeed",
+                  "queue": "conformance",
+                  "state": "succeeded",
+                  "priority": 0,
+                  "createdAt": {
+                    "$type": "timestamp"
+                  },
+                  "deadlineAt": null,
+                  "maxAttempts": 25,
+                  "retryPolicy": null,
+                  "blockedReason": null,
+                  "concurrencyKey": null,
+                  "dependencyPolicy": null,
+                  "prerequisiteJobId": null,
+                  "executionTimeoutMs": null,
+                  "prerequisiteJobIds": [],
+                  "dependencyReleasedAt": null
+                },
+                "progress": null,
+                "canSignal": true,
+                "durability": null,
+                "signalWait": null,
+                "checkpoints": [],
+                "childLineage": {
+                  "records": [],
+                  "truncated": false
+                },
+                "redriveLineage": {
+                  "records": [],
+                  "truncated": false
+                },
+                "batchExecutions": [],
+                "concurrencyPolicy": null,
+                "dependencyLineage": {
+                  "records": [],
+                  "truncated": false
+                }
               }
             }
           }
@@ -4475,33 +4475,18 @@
             "status": 200,
             "body": {
               "json": {
-                "capturedAt": {
-                  "$type": "timestamp"
-                },
-                "canComplete": true,
-                "canSignal": true,
-                "diagnostics": {
-                  "pendingSignals": 1,
-                  "pendingHumanDecisions": 1,
-                  "overdue": 0,
-                  "oldestPendingAgeMs": {
-                    "$type": "number"
-                  },
-                  "rejectedDeliveries": 0,
-                  "capped": false
-                },
                 "waits": [
                   {
+                    "name": "review",
                     "jobId": {
                       "$ref": "humanJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.human",
-                    "name": "review",
+                    "attempt": 1,
                     "context": {
                       "question": "Approve the conformance run?"
                     },
-                    "attempt": 1,
+                    "jobType": "conformance.human",
                     "createdAt": {
                       "$type": "timestamp"
                     },
@@ -4510,15 +4495,30 @@
                     }
                   }
                 ],
+                "canSignal": true,
+                "capturedAt": {
+                  "$type": "timestamp"
+                },
+                "canComplete": true,
+                "diagnostics": {
+                  "capped": false,
+                  "overdue": 0,
+                  "pendingSignals": 1,
+                  "oldestPendingAgeMs": {
+                    "$type": "number"
+                  },
+                  "rejectedDeliveries": 0,
+                  "pendingHumanDecisions": 1
+                },
                 "signalWaits": [
                   {
+                    "name": "approval",
                     "jobId": {
                       "$ref": "signalJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.signal",
-                    "name": "approval",
                     "attempt": 1,
+                    "jobType": "conformance.signal",
                     "createdAt": {
                       "$type": "timestamp"
                     },
@@ -5391,208 +5391,178 @@
             "status": 200,
             "body": {
               "json": {
-                "capturedAt": {
-                  "$type": "timestamp"
-                },
-                "canCompleteHumanWait": false,
-                "filter": "all",
-                "queue": null,
-                "worker": null,
-                "jobType": null,
-                "priority": null,
-                "sort": "updated",
-                "tags": [],
-                "search": null,
-                "page": 1,
-                "pageSize": 50,
-                "total": 8,
                 "jobs": [
                   {
                     "id": {
                       "$ref": "purgeTargetJob"
                     },
-                    "queue": "conformance-purge",
-                    "type": "conformance.purge",
-                    "priority": 0,
-                    "state": "ready",
-                    "blockedReason": null,
-                    "prerequisiteJobIds": [],
-                    "attempt": 1,
-                    "maxAttempts": 25,
-                    "retryPolicy": null,
-                    "deadlineAt": null,
-                    "executionTimeoutMs": null,
                     "tags": [],
+                    "type": "conformance.purge",
+                    "wait": null,
                     "keyed": false,
-                    "cancellation": null,
+                    "queue": "conformance-purge",
                     "runAt": {
                       "$type": "timestamp"
                     },
+                    "state": "ready",
+                    "wakeAt": null,
+                    "attempt": 1,
+                    "priority": 0,
+                    "waitName": null,
                     "workerId": null,
-                    "lastWorkerId": null,
-                    "finishedAt": null,
-                    "errorMessage": null,
                     "createdAt": {
                       "$type": "timestamp"
                     },
+                    "humanWait": null,
                     "updatedAt": {
                       "$type": "timestamp"
                     },
+                    "deadlineAt": null,
                     "durability": null,
-                    "waitName": null,
-                    "wakeAt": null,
-                    "wait": null,
+                    "finishedAt": null,
                     "signalWait": null,
-                    "humanWait": null
+                    "maxAttempts": 25,
+                    "retryPolicy": null,
+                    "cancellation": null,
+                    "errorMessage": null,
+                    "lastWorkerId": null,
+                    "blockedReason": null,
+                    "executionTimeoutMs": null,
+                    "prerequisiteJobIds": []
                   },
                   {
                     "id": {
                       "$ref": "cancelTargetJob"
                     },
-                    "queue": "conformance",
-                    "type": "conformance.cancel-target",
-                    "priority": 0,
-                    "state": "ready",
-                    "blockedReason": null,
-                    "prerequisiteJobIds": [],
-                    "attempt": 1,
-                    "maxAttempts": 25,
-                    "retryPolicy": null,
-                    "deadlineAt": null,
-                    "executionTimeoutMs": null,
                     "tags": [],
+                    "type": "conformance.cancel-target",
+                    "wait": null,
                     "keyed": false,
-                    "cancellation": null,
+                    "queue": "conformance",
                     "runAt": {
                       "$type": "timestamp"
                     },
+                    "state": "ready",
+                    "wakeAt": null,
+                    "attempt": 1,
+                    "priority": 0,
+                    "waitName": null,
                     "workerId": null,
-                    "lastWorkerId": null,
-                    "finishedAt": null,
-                    "errorMessage": null,
                     "createdAt": {
                       "$type": "timestamp"
                     },
+                    "humanWait": null,
                     "updatedAt": {
                       "$type": "timestamp"
                     },
+                    "deadlineAt": null,
                     "durability": null,
-                    "waitName": null,
-                    "wakeAt": null,
-                    "wait": null,
+                    "finishedAt": null,
                     "signalWait": null,
-                    "humanWait": null
+                    "maxAttempts": 25,
+                    "retryPolicy": null,
+                    "cancellation": null,
+                    "errorMessage": null,
+                    "lastWorkerId": null,
+                    "blockedReason": null,
+                    "executionTimeoutMs": null,
+                    "prerequisiteJobIds": []
                   },
                   {
                     "id": {
                       "$ref": "scheduledJob"
                     },
-                    "queue": "conformance",
-                    "type": "conformance.scheduled",
-                    "priority": 0,
-                    "state": "scheduled",
-                    "blockedReason": null,
-                    "prerequisiteJobIds": [],
-                    "attempt": 1,
-                    "maxAttempts": 25,
-                    "retryPolicy": null,
-                    "deadlineAt": null,
-                    "executionTimeoutMs": null,
                     "tags": [],
+                    "type": "conformance.scheduled",
+                    "wait": null,
                     "keyed": false,
-                    "cancellation": null,
+                    "queue": "conformance",
                     "runAt": "2031-01-01T00:00:00.000Z",
+                    "state": "scheduled",
+                    "wakeAt": null,
+                    "attempt": 1,
+                    "priority": 0,
+                    "waitName": null,
                     "workerId": null,
-                    "lastWorkerId": null,
-                    "finishedAt": null,
-                    "errorMessage": null,
                     "createdAt": {
                       "$type": "timestamp"
                     },
+                    "humanWait": null,
                     "updatedAt": {
                       "$type": "timestamp"
                     },
+                    "deadlineAt": null,
                     "durability": null,
-                    "waitName": null,
-                    "wakeAt": null,
-                    "wait": null,
+                    "finishedAt": null,
                     "signalWait": null,
-                    "humanWait": null
+                    "maxAttempts": 25,
+                    "retryPolicy": null,
+                    "cancellation": null,
+                    "errorMessage": null,
+                    "lastWorkerId": null,
+                    "blockedReason": null,
+                    "executionTimeoutMs": null,
+                    "prerequisiteJobIds": []
                   },
                   {
                     "id": {
                       "$ref": "readyJob"
                     },
-                    "queue": "conformance",
-                    "type": "conformance.ready",
-                    "priority": 5,
-                    "state": "ready",
-                    "blockedReason": null,
-                    "prerequisiteJobIds": [],
-                    "attempt": 1,
-                    "maxAttempts": 25,
-                    "retryPolicy": null,
-                    "deadlineAt": null,
-                    "executionTimeoutMs": null,
                     "tags": [
                       "conformance"
                     ],
+                    "type": "conformance.ready",
+                    "wait": null,
                     "keyed": false,
-                    "cancellation": null,
+                    "queue": "conformance",
                     "runAt": {
                       "$type": "timestamp"
                     },
+                    "state": "ready",
+                    "wakeAt": null,
+                    "attempt": 1,
+                    "priority": 5,
+                    "waitName": null,
                     "workerId": null,
-                    "lastWorkerId": null,
-                    "finishedAt": null,
-                    "errorMessage": null,
                     "createdAt": {
                       "$type": "timestamp"
                     },
+                    "humanWait": null,
                     "updatedAt": {
                       "$type": "timestamp"
                     },
+                    "deadlineAt": null,
                     "durability": null,
-                    "waitName": null,
-                    "wakeAt": null,
-                    "wait": null,
+                    "finishedAt": null,
                     "signalWait": null,
-                    "humanWait": null
+                    "maxAttempts": 25,
+                    "retryPolicy": null,
+                    "cancellation": null,
+                    "errorMessage": null,
+                    "lastWorkerId": null,
+                    "blockedReason": null,
+                    "executionTimeoutMs": null,
+                    "prerequisiteJobIds": []
                   },
                   {
                     "id": {
                       "$ref": "humanJob"
                     },
-                    "queue": "conformance",
-                    "type": "conformance.human",
-                    "priority": 0,
-                    "state": "scheduled",
-                    "blockedReason": null,
-                    "prerequisiteJobIds": [],
-                    "attempt": 1,
-                    "maxAttempts": 25,
-                    "retryPolicy": null,
-                    "deadlineAt": null,
-                    "executionTimeoutMs": null,
                     "tags": [],
+                    "type": "conformance.human",
+                    "wait": null,
                     "keyed": false,
-                    "cancellation": null,
+                    "queue": "conformance",
                     "runAt": "9999-12-31T00:00:00.000Z",
+                    "state": "scheduled",
+                    "wakeAt": null,
+                    "attempt": 1,
+                    "priority": 0,
+                    "waitName": "review",
                     "workerId": null,
-                    "lastWorkerId": null,
-                    "finishedAt": null,
-                    "errorMessage": null,
                     "createdAt": {
                       "$type": "timestamp"
                     },
-                    "updatedAt": {
-                      "$type": "timestamp"
-                    },
-                    "durability": null,
-                    "waitName": "review",
-                    "wakeAt": null,
-                    "wait": null,
-                    "signalWait": null,
                     "humanWait": {
                       "name": "review",
                       "context": {
@@ -5601,132 +5571,162 @@
                       "deadlineAt": {
                         "$type": "timestamp"
                       }
-                    }
+                    },
+                    "updatedAt": {
+                      "$type": "timestamp"
+                    },
+                    "deadlineAt": null,
+                    "durability": null,
+                    "finishedAt": null,
+                    "signalWait": null,
+                    "maxAttempts": 25,
+                    "retryPolicy": null,
+                    "cancellation": null,
+                    "errorMessage": null,
+                    "lastWorkerId": null,
+                    "blockedReason": null,
+                    "executionTimeoutMs": null,
+                    "prerequisiteJobIds": []
                   },
                   {
                     "id": {
                       "$ref": "signalJob"
                     },
-                    "queue": "conformance",
-                    "type": "conformance.signal",
-                    "priority": 0,
-                    "state": "scheduled",
-                    "blockedReason": null,
-                    "prerequisiteJobIds": [],
-                    "attempt": 1,
-                    "maxAttempts": 25,
-                    "retryPolicy": null,
-                    "deadlineAt": null,
-                    "executionTimeoutMs": null,
                     "tags": [],
+                    "type": "conformance.signal",
+                    "wait": null,
                     "keyed": false,
-                    "cancellation": null,
+                    "queue": "conformance",
                     "runAt": "9999-12-31T00:00:00.000Z",
+                    "state": "scheduled",
+                    "wakeAt": null,
+                    "attempt": 1,
+                    "priority": 0,
+                    "waitName": "approval",
                     "workerId": null,
-                    "lastWorkerId": null,
-                    "finishedAt": null,
-                    "errorMessage": null,
                     "createdAt": {
                       "$type": "timestamp"
                     },
+                    "humanWait": null,
                     "updatedAt": {
                       "$type": "timestamp"
                     },
+                    "deadlineAt": null,
                     "durability": null,
-                    "waitName": "approval",
-                    "wakeAt": null,
-                    "wait": null,
+                    "finishedAt": null,
                     "signalWait": {
                       "name": "approval",
                       "deadlineAt": {
                         "$type": "timestamp"
                       }
                     },
-                    "humanWait": null
+                    "maxAttempts": 25,
+                    "retryPolicy": null,
+                    "cancellation": null,
+                    "errorMessage": null,
+                    "lastWorkerId": null,
+                    "blockedReason": null,
+                    "executionTimeoutMs": null,
+                    "prerequisiteJobIds": []
                   },
                   {
                     "id": {
                       "$ref": "failedJob"
                     },
-                    "queue": "conformance",
-                    "type": "conformance.fail",
-                    "priority": 0,
-                    "state": "failed",
-                    "blockedReason": null,
-                    "prerequisiteJobIds": [],
-                    "attempt": 1,
-                    "maxAttempts": 1,
-                    "retryPolicy": null,
-                    "deadlineAt": null,
-                    "executionTimeoutMs": null,
                     "tags": [],
+                    "type": "conformance.fail",
+                    "wait": null,
                     "keyed": false,
-                    "cancellation": null,
+                    "queue": "conformance",
                     "runAt": {
                       "$type": "timestamp"
                     },
+                    "state": "failed",
+                    "wakeAt": null,
+                    "attempt": 1,
+                    "priority": 0,
+                    "waitName": null,
                     "workerId": null,
-                    "lastWorkerId": null,
-                    "finishedAt": {
-                      "$type": "timestamp"
-                    },
-                    "errorMessage": "conformance.fail failed",
                     "createdAt": {
                       "$type": "timestamp"
                     },
+                    "humanWait": null,
                     "updatedAt": {
                       "$type": "timestamp"
                     },
+                    "deadlineAt": null,
                     "durability": null,
-                    "waitName": null,
-                    "wakeAt": null,
-                    "wait": null,
+                    "finishedAt": {
+                      "$type": "timestamp"
+                    },
                     "signalWait": null,
-                    "humanWait": null
+                    "maxAttempts": 1,
+                    "retryPolicy": null,
+                    "cancellation": null,
+                    "errorMessage": "conformance.fail failed",
+                    "lastWorkerId": null,
+                    "blockedReason": null,
+                    "executionTimeoutMs": null,
+                    "prerequisiteJobIds": []
                   },
                   {
                     "id": {
                       "$ref": "succeededJob"
                     },
-                    "queue": "conformance",
-                    "type": "conformance.succeed",
-                    "priority": 0,
-                    "state": "succeeded",
-                    "blockedReason": null,
-                    "prerequisiteJobIds": [],
-                    "attempt": 1,
-                    "maxAttempts": 25,
-                    "retryPolicy": null,
-                    "deadlineAt": null,
-                    "executionTimeoutMs": null,
                     "tags": [
                       "conformance"
                     ],
+                    "type": "conformance.succeed",
+                    "wait": null,
                     "keyed": false,
-                    "cancellation": null,
+                    "queue": "conformance",
                     "runAt": {
                       "$type": "timestamp"
                     },
+                    "state": "succeeded",
+                    "wakeAt": null,
+                    "attempt": 1,
+                    "priority": 0,
+                    "waitName": null,
                     "workerId": null,
-                    "lastWorkerId": null,
-                    "finishedAt": {
-                      "$type": "timestamp"
-                    },
-                    "errorMessage": null,
                     "createdAt": {
                       "$type": "timestamp"
                     },
+                    "humanWait": null,
                     "updatedAt": {
                       "$type": "timestamp"
                     },
+                    "deadlineAt": null,
                     "durability": null,
-                    "waitName": null,
-                    "wakeAt": null,
-                    "wait": null,
+                    "finishedAt": {
+                      "$type": "timestamp"
+                    },
                     "signalWait": null,
-                    "humanWait": null
+                    "maxAttempts": 25,
+                    "retryPolicy": null,
+                    "cancellation": null,
+                    "errorMessage": null,
+                    "lastWorkerId": null,
+                    "blockedReason": null,
+                    "executionTimeoutMs": null,
+                    "prerequisiteJobIds": []
                   }
-                ]
+                ],
+                "page": 1,
+                "sort": "updated",
+                "tags": [],
+                "queue": null,
+                "total": 8,
+                "filter": "all",
+                "search": null,
+                "worker": null,
+                "jobType": null,
+                "pageSize": 50,
+                "priority": null,
+                "capturedAt": {
+                  "$type": "timestamp"
+                },
+                "canCompleteHumanWait": false
               }
             }
           }
@@ -5740,43 +5740,43 @@
             "status": 200,
             "body": {
               "json": {
-                "capturedAt": {
-                  "$type": "timestamp"
-                },
-                "canManageWorkers": false,
                 "workers": [
                   {
                     "id": "conformance-worker",
+                    "pid": 4242,
+                    "paused": false,
                     "queues": [
                       "conformance"
                     ],
-                    "scheduleNamespaces": [
-                      "conformance"
-                    ],
-                    "hostname": "conformance-host",
-                    "pid": 4242,
-                    "activeJobs": 0,
-                    "concurrency": 2,
-                    "activeSlots": 0,
                     "draining": false,
-                    "completedAttempts": 2,
-                    "failedAttempts": 1,
-                    "averageExecutionMs": {
-                      "$type": "number"
-                    },
-                    "lastSeenAt": {
-                      "$type": "timestamp"
-                    },
+                    "hostname": "conformance-host",
                     "startedAt": {
                       "$type": "timestamp"
                     },
+                    "activeJobs": 0,
+                    "lastSeenAt": {
+                      "$type": "timestamp"
+                    },
                     "registered": true,
+                    "activeSlots": 0,
+                    "concurrency": 2,
+                    "failedAttempts": 1,
                     "lastHeartbeatAt": {
                       "$type": "timestamp"
                     },
-                    "paused": false
+                    "completedAttempts": 2,
+                    "averageExecutionMs": {
+                      "$type": "number"
+                    },
+                    "scheduleNamespaces": [
+                      "conformance"
+                    ]
                   }
-                ]
+                ],
+                "capturedAt": {
+                  "$type": "timestamp"
+                },
+                "canManageWorkers": false
               }
             }
           }
@@ -5790,100 +5790,34 @@
             "status": 200,
             "body": {
               "json": {
-                "capturedAt": {
-                  "$type": "timestamp"
-                },
+                "workers": [
+                  {
+                    "id": "conformance-worker",
+                    "queue": "conformance",
+                    "pollMs": 250,
+                    "queues": [
+                      "conformance"
+                    ],
+                    "leaseMs": 30000,
+                    "lastSeenAt": {
+                      "$type": "timestamp"
+                    },
+                    "concurrency": 2,
+                    "heartbeatMs": 10000,
+                    "registryIntervalMs": 5000,
+                    "maintenanceIntervalMs": 1000,
+                    "maintenanceTaskPollMs": 60000
+                  }
+                ],
                 "editable": false,
-                "maintenance": {
-                  "timezone": "UTC",
-                  "partitionPreparationIntervalMs": 21600000,
-                  "terminalCleanupIntervalMs": 300000,
-                  "historyRetentionLocalTime": "03:00",
-                  "statisticsRollupIntervalMs": 60000,
-                  "statisticsGroupLimit": 200,
-                  "statisticsRecomputeBuckets": 2,
-                  "provenance": {
-                    "timezone": {
-                      "source": "application",
-                      "applicationDefault": "UTC"
-                    },
-                    "partitionPreparationIntervalMs": {
-                      "source": "application",
-                      "applicationDefault": 21600000
-                    },
-                    "terminalCleanupIntervalMs": {
-                      "source": "application",
-                      "applicationDefault": 300000
-                    },
-                    "historyRetentionLocalTime": {
-                      "source": "application",
-                      "applicationDefault": "03:00"
-                    },
-                    "statisticsRollupIntervalMs": {
-                      "source": "application",
-                      "applicationDefault": 60000
-                    },
-                    "statisticsGroupLimit": {
-                      "source": "application",
-                      "applicationDefault": 200
-                    },
-                    "statisticsRecomputeBuckets": {
-                      "source": "application",
-                      "applicationDefault": 2
-                    }
-                  },
+                "retention": {
                   "updatedAt": {
                     "$type": "timestamp"
-                  }
-                },
-                "retention": {
-                  "jobIdentityRetentionDays": 14,
-                  "terminalOutcomeRetentionDays": 14,
-                  "jobEventRetentionDays": 14,
-                  "attemptHistoryRetentionDays": 14,
-                  "scheduleOccurrenceRetentionDays": 14,
-                  "statisticsRetentionDays": 14,
-                  "terminalJobPruneLimit": 1000,
-                  "historyPartitionsPerPass": 4,
-                  "defaultPartitionRowsPerPass": 10000,
-                  "occurrenceRowsPerPass": 10000,
-                  "statisticsRowsPerPass": 10000,
+                  },
                   "provenance": {
-                    "jobIdentityRetentionDays": {
-                      "source": "application",
-                      "applicationDefault": 14
-                    },
-                    "terminalOutcomeRetentionDays": {
-                      "source": "application",
-                      "applicationDefault": 14
-                    },
                     "jobEventRetentionDays": {
                       "source": "application",
                       "applicationDefault": 14
-                    },
-                    "attemptHistoryRetentionDays": {
-                      "source": "application",
-                      "applicationDefault": 14
-                    },
-                    "scheduleOccurrenceRetentionDays": {
-                      "source": "application",
-                      "applicationDefault": 14
-                    },
-                    "statisticsRetentionDays": {
-                      "source": "application",
-                      "applicationDefault": 14
-                    },
-                    "terminalJobPruneLimit": {
-                      "source": "application",
-                      "applicationDefault": 1000
-                    },
-                    "historyPartitionsPerPass": {
-                      "source": "application",
-                      "applicationDefault": 4
-                    },
-                    "defaultPartitionRowsPerPass": {
-                      "source": "application",
-                      "applicationDefault": 10000
                     },
                     "occurrenceRowsPerPass": {
                       "source": "application",
@@ -5892,11 +5826,96 @@
                     "statisticsRowsPerPass": {
                       "source": "application",
                       "applicationDefault": 10000
+                    },
+                    "terminalJobPruneLimit": {
+                      "source": "application",
+                      "applicationDefault": 1000
+                    },
+                    "statisticsRetentionDays": {
+                      "source": "application",
+                      "applicationDefault": 14
+                    },
+                    "historyPartitionsPerPass": {
+                      "source": "application",
+                      "applicationDefault": 4
+                    },
+                    "jobIdentityRetentionDays": {
+                      "source": "application",
+                      "applicationDefault": 14
+                    },
+                    "attemptHistoryRetentionDays": {
+                      "source": "application",
+                      "applicationDefault": 14
+                    },
+                    "defaultPartitionRowsPerPass": {
+                      "source": "application",
+                      "applicationDefault": 10000
+                    },
+                    "terminalOutcomeRetentionDays": {
+                      "source": "application",
+                      "applicationDefault": 14
+                    },
+                    "scheduleOccurrenceRetentionDays": {
+                      "source": "application",
+                      "applicationDefault": 14
                     }
                   },
+                  "jobEventRetentionDays": 14,
+                  "occurrenceRowsPerPass": 10000,
+                  "statisticsRowsPerPass": 10000,
+                  "terminalJobPruneLimit": 1000,
+                  "statisticsRetentionDays": 14,
+                  "historyPartitionsPerPass": 4,
+                  "jobIdentityRetentionDays": 14,
+                  "attemptHistoryRetentionDays": 14,
+                  "defaultPartitionRowsPerPass": 10000,
+                  "terminalOutcomeRetentionDays": 14,
+                  "scheduleOccurrenceRetentionDays": 14
+                },
+                "capturedAt": {
+                  "$type": "timestamp"
+                },
+                "maintenance": {
+                  "timezone": "UTC",
                   "updatedAt": {
                     "$type": "timestamp"
-                  }
+                  },
+                  "provenance": {
+                    "timezone": {
+                      "source": "application",
+                      "applicationDefault": "UTC"
+                    },
+                    "statisticsGroupLimit": {
+                      "source": "application",
+                      "applicationDefault": 200
+                    },
+                    "historyRetentionLocalTime": {
+                      "source": "application",
+                      "applicationDefault": "03:00"
+                    },
+                    "terminalCleanupIntervalMs": {
+                      "source": "application",
+                      "applicationDefault": 300000
+                    },
+                    "statisticsRecomputeBuckets": {
+                      "source": "application",
+                      "applicationDefault": 2
+                    },
+                    "statisticsRollupIntervalMs": {
+                      "source": "application",
+                      "applicationDefault": 60000
+                    },
+                    "partitionPreparationIntervalMs": {
+                      "source": "application",
+                      "applicationDefault": 21600000
+                    }
+                  },
+                  "statisticsGroupLimit": 200,
+                  "historyRetentionLocalTime": "03:00",
+                  "terminalCleanupIntervalMs": 300000,
+                  "statisticsRecomputeBuckets": 2,
+                  "statisticsRollupIntervalMs": 60000,
+                  "partitionPreparationIntervalMs": 21600000
                 },
                 "recommendationInputs": {
                   "reasons": [
@@ -5910,13 +5929,17 @@
                     }
                   ],
                   "statistics": {
-                    "rolledUpThrough": {
-                      "$type": "timestamp"
-                    },
                     "lagMs": {
                       "$type": "number"
                     },
-                    "lastRunAt": null
+                    "lastRunAt": null,
+                    "rolledUpThrough": {
+                      "$type": "timestamp"
+                    }
+                  },
+                  "enqueueRate": {
+                    "jobs": 8,
+                    "windowMs": 3600000
                   },
                   "defaultHistoryRows": {
                     "jobEvents": 0,
@@ -5925,31 +5948,8 @@
                   "defaultHistoryRowsCapped": {
                     "jobEvents": false,
                     "attemptHistory": false
-                  },
-                  "enqueueRate": {
-                    "jobs": 8,
-                    "windowMs": 3600000
                   }
-                },
-                "workers": [
-                  {
-                    "id": "conformance-worker",
-                    "queue": "conformance",
-                    "queues": [
-                      "conformance"
-                    ],
-                    "concurrency": 2,
-                    "leaseMs": 30000,
-                    "heartbeatMs": 10000,
-                    "pollMs": 250,
-                    "maintenanceIntervalMs": 1000,
-                    "maintenanceTaskPollMs": 60000,
-                    "registryIntervalMs": 5000,
-                    "lastSeenAt": {
-                      "$type": "timestamp"
-                    }
-                  }
-                ]
+                }
               }
             }
           },
@@ -5966,33 +5966,18 @@
             "status": 200,
             "body": {
               "json": {
-                "capturedAt": {
-                  "$type": "timestamp"
-                },
-                "canComplete": false,
-                "canSignal": false,
-                "diagnostics": {
-                  "pendingSignals": 1,
-                  "pendingHumanDecisions": 1,
-                  "overdue": 0,
-                  "oldestPendingAgeMs": {
-                    "$type": "number"
-                  },
-                  "rejectedDeliveries": 0,
-                  "capped": false
-                },
                 "waits": [
                   {
+                    "name": "review",
                     "jobId": {
                       "$ref": "humanJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.human",
-                    "name": "review",
+                    "attempt": 1,
                     "context": {
                       "question": "Approve the conformance run?"
                     },
-                    "attempt": 1,
+                    "jobType": "conformance.human",
                     "createdAt": {
                       "$type": "timestamp"
                     },
@@ -6001,15 +5986,30 @@
                     }
                   }
                 ],
+                "canSignal": false,
+                "capturedAt": {
+                  "$type": "timestamp"
+                },
+                "canComplete": false,
+                "diagnostics": {
+                  "capped": false,
+                  "overdue": 0,
+                  "pendingSignals": 1,
+                  "oldestPendingAgeMs": {
+                    "$type": "number"
+                  },
+                  "rejectedDeliveries": 0,
+                  "pendingHumanDecisions": 1
+                },
                 "signalWaits": [
                   {
+                    "name": "approval",
                     "jobId": {
                       "$ref": "signalJob"
                     },
                     "queue": "conformance",
-                    "jobType": "conformance.signal",
-                    "name": "approval",
                     "attempt": 1,
+                    "jobType": "conformance.signal",
                     "createdAt": {
                       "$type": "timestamp"
                     },

--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -24,6 +24,12 @@ Requires **schema v1** and Go **1.25** or newer.
   `workhorse.dashboard_run_task_now_v1`, which is removed from the schema. The action now records
   the authenticated actor, the reason, and the request identity in its `promoted` event, matching
   the TypeScript dashboard server.
+- **Dashboard timestamps.** Every timestamp a dashboard mutation returns is now UTC with exactly
+  three fractional digits, matching the TypeScript and Python backends. It was `time.RFC3339Nano`,
+  which dropped a trailing zero and passed through PostgreSQL's microseconds, so this module
+  answered `2026-09-02T14:30:00Z` and `...:00.123456Z` where the other two answer
+  `2026-09-02T14:30:00.000Z` and `...:00.123Z`. A client that compares or displays the string sees
+  a different value; one that parses it does not.
 
 ### Upgrade notes
 
@@ -31,7 +37,8 @@ Requires **schema v1** and Go **1.25** or newer.
   beta installed: `workhorse.valid_tags` was renamed `workhorse.valid_tags_v1` and
   `workhorse.dashboard_run_task_now_v1` was removed. A database installed by any beta reports
   version 1 and passes the compatibility check, yet holds the old function names. You must recreate the database and
-  install the new baseline with `npx --package @stablemates/workhorse workhorse schema install`.
+  install the new baseline with
+  `npx --package @stablemates/workhorse@0.1.0 workhorse schema install`.
   This is the last release that asks for a recreation: from `0.1.0` the schema is frozen as the
   migration baseline, and later releases upgrade a database in place.
 

--- a/go/dashboard/backend.go
+++ b/go/dashboard/backend.go
@@ -83,7 +83,7 @@ func normalizeJSON(value any) any {
 	case string:
 		if strings.Contains(current, "T") {
 			if moment, err := time.Parse(time.RFC3339Nano, current); err == nil {
-				return moment.UTC().Format("2006-01-02T15:04:05.000Z")
+				return moment.UTC().Format(dashboardTimestampLayout)
 			}
 		}
 	}
@@ -127,12 +127,21 @@ func oneRow(rows []workhorse.Row, name string) (workhorse.Row, error) {
 	return rows[0], nil
 }
 
+// One instant must serialize to one string in every language, so this is the layout the whole
+// dashboard uses. It matches JavaScript `Date.toISOString()` and Python
+// `isoformat(timespec="milliseconds")`: UTC, always three fractional digits.
+//
+// `time.RFC3339Nano` cannot be used here. It drops trailing zeros, so a whole second becomes
+// `...T00:00:00Z` where the other two backends write `...T00:00:00.000Z`, and it keeps microsecond
+// precision PostgreSQL supplies where the other two truncate to milliseconds.
+const dashboardTimestampLayout = "2006-01-02T15:04:05.000Z"
+
 func timestamp(value any) any {
 	if value == nil {
 		return nil
 	}
 	if moment, ok := value.(time.Time); ok {
-		return moment.UTC().Format(time.RFC3339Nano)
+		return moment.UTC().Format(dashboardTimestampLayout)
 	}
 	return value
 }

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -46,7 +46,8 @@ Requires **schema v1** and Python **3.12** or newer.
   beta installed: `workhorse.valid_tags` was renamed `workhorse.valid_tags_v1` and
   `workhorse.dashboard_run_task_now_v1` was removed. A database installed by any beta reports
   version 1 and passes the compatibility check, yet holds the old function names. You must recreate the database and
-  install the new baseline with `npx --package @stablemates/workhorse workhorse schema install`.
+  install the new baseline with
+  `npx --package @stablemates/workhorse@0.1.0 workhorse schema install`.
   This is the last release that asks for a recreation: from `0.1.0` the schema is frozen as the
   migration baseline, and later releases upgrade a database in place.
 


### PR DESCRIPTION
Closes [WH-606](https://ontrack.sh/projects/WH/issues/WH-606).

## The Issue's premise was wrong, and the real gap was narrower and worse

WH-606 said `runTaskNow` and `enqueueTest` appear in no scenario. They appear in seven: a success
exchange each in `mutations`, cross-origin rejections, read-only `FORBIDDEN`, and 400/404 error
envelopes. What was missing is the thing WH-601 actually changed.

`mutations/run-task-now` asserted `status`, `state`, and `runAt`. A backend that sends the four
arguments of `workhorse.run_task_now_v1` in the wrong order returns exactly that body. The audited
`promoted` event — the entire point of moving off `dashboard_run_task_now_v1` — was asserted
nowhere.

## Four exchanges

- **`run-task-now-promoted-event`** reads the job's `promoted` event and pins `requested_by`,
  `request_reason`, `request_id_preview`, `request_id_digest`, and `request_id_length` literally.
  `requested_by` records `conformance`, the authenticated actor, not the `browser-operator` the
  request audit carries — so the substitution every backend must perform is now pinned too.
- **`run-task-now-repeat`** calls the same task again and requires `already_ready`. A backend that
  replied without committing would answer `released` twice.
- **`run-task-now-already-ready`** covers a task that was never scheduled.
- **`run-task-now-waiting`** covers a task suspended at a durable signal: `waiting`, state
  unchanged.

`enqueueTest` gains the accepting half of a rule all three backends hand-write (Zod's `.refine`
cannot be expressed in the generated JSON Schema, so Go and Python each open-code it): the
`feature` kind with a family present. Only the rejecting half had a scenario, so an over-eager
open-coded check would have passed.

## It immediately found a cross-language divergence

`run-task-now-waiting` is the fixture's first deterministic timestamp — a signal-waiting task's
`run_at` is the fixed far-future sentinel. Go failed it:

```
run-task-now-waiting.body.json.runAt expected "9999-12-31T00:00:00.000Z", received "9999-12-31T00:00:00Z"
```

`go/dashboard/backend.go` had two timestamp paths. `normalizeJSON`, for values arriving as JSON
from a `jsonb` procedure, used `"2006-01-02T15:04:05.000Z"`. `timestamp()`, for values arriving as
a `time.Time` column, used `time.RFC3339Nano` — which drops a trailing zero and keeps PostgreSQL's
microseconds. So every mutation timestamp Go returned (`runAt`, `requestedAt`, `finishedAt`,
`deliveredAt`, `completedAt`) differed from what TypeScript and Python return for the same instant.

Every other timestamp in the fixture is clock-derived and matches through `{"$type": "timestamp"}`,
which is why this survived. Both Go paths now share one layout constant, and
`dashboard/v1/README.md` states the format as part of the contract.

## Two commits, because the generator rewrites the file

`pnpm dashboard-conformance:generate` rewrites ~2000 lines of the committed fixture with no input
change: key ordering moved to PostgreSQL's `jsonb` order when the dashboard reads became
database-owned procedures (ADR 0040), and the fixture was never regenerated. Parsed, the before and
after are deeply equal. `37723078` lands that churn alone so `5114cfa7` reads as what it is: 185
added lines.

## Verification

`vitest run` 1688 across 140 files, `pytest` 155, `go test ./...` all packages, plus
`sql-catalogues:check`, `dashboard-spec:check`, `dashboard-bindings:check`, `parity:check`,
`readme-alignment:check`, `format:check`, and `go:lint`.

The Issue's third acceptance item asked for a negative control. Both languages, plausible mistakes
rather than a literal revert (a literal revert calls a function the schema no longer has):

- Go, `audit["reason"]` and `audit["requestId"]` swapped →
  `run-task-now-promoted-event.body.json.events[0].details.request_id_length expected 19, received 20`
- Python, same swap →
  `AssertionError: ...details.request_reason: assert 'conformance-request' == 'conformance exchange'`

Both reverted; `git diff` against both files is empty.

https://claude.ai/code/session_01LbQjiy3riBwzkuXmReRNwb
