### PR TITLE
Run the demo's schema step from the deployment pipeline, not the container

### DIFF
--- a/.kamal/hooks/demo/pre-deploy
+++ b/.kamal/hooks/demo/pre-deploy
@@ -13,7 +13,7 @@ set -eu
 
 : "${KAMAL_VERSION:?Kamal sets KAMAL_VERSION for its hooks}"
 
-repository_root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+repository_root=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 
 # Kamal uploads each role's secret environment file when it boots a container, and it runs this
 # hook before that, so the file is the one the previous deploy wrote. That is correct for every

--- a/.kamal/hooks/pre-deploy
+++ b/.kamal/hooks/pre-deploy
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Parameterized example. Kamal runs this after it builds and pushes the image and before it boots
+# any container from it, so it is where the demo's schema step belongs.
+#
+# ADR 0053 states the rule this implements: a deployment runs the migration once, from the pipeline,
+# before any process from the new release starts, and no component migrates on start. A component
+# that migrated itself would be as many concurrent migrators as it has nodes.
+#
+# `kamal app exec` runs the command in a new container from the version being deployed, with the
+# role's environment and volumes. The schema tool is therefore the one inside the image that is
+# about to serve traffic, which is what makes its version match the application by construction.
+set -eu
+
+: "${KAMAL_VERSION:?Kamal sets KAMAL_VERSION for its hooks}"
+
+repository_root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+
+# Kamal uploads each role's secret environment file when it boots a container, and it runs this
+# hook before that, so the file is the one the previous deploy wrote. That is correct for every
+# deploy after the first. A first installation has no file yet and must run the schema step once
+# from the host; DEPLOYMENT.md says so.
+#
+# dist/prepare-schema.js installs or migrates the Workhorse schema and the demo's own tables in
+# every configured workspace, then verifies each one with the checks the server makes at startup.
+# A refusal exits non-zero, which fails the deploy before the container swap.
+exec bundle exec kamal app exec \
+  --version "$KAMAL_VERSION" \
+  --config-file "$repository_root/config/deploy.yml" \
+  "node dist/prepare-schema.js"

--- a/config/deploy.site.yml
+++ b/config/deploy.site.yml
@@ -2,6 +2,9 @@
 service: workhorse-site
 image: workhorse-site
 minimum_version: 2.12.0
+# The site has no hooks. Naming its own directory keeps Kamal's shared default from running the
+# demo's schema step here.
+hooks_path: .kamal/hooks/site
 
 servers:
   web:

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -2,6 +2,10 @@
 service: workhorse-demo
 image: workhorse-demo
 minimum_version: 2.12.0
+# One hooks directory per application. Kamal defaults to `.kamal/hooks` relative to the working
+# directory, which both example configs share, so an unqualified directory would run the demo's
+# schema step during a site deploy.
+hooks_path: .kamal/hooks/demo
 
 servers:
   web:

--- a/typescript/demo/DEPLOYMENT.md
+++ b/typescript/demo/DEPLOYMENT.md
@@ -115,8 +115,47 @@ scripts/deploy-demo.sh
 
 The demo receives `DATABASE_URL_PRIMARY` and `DATABASE_URL_SECONDARY` as runtime secrets. This
 enables the production and staging workspace switcher. A routine deploy never creates, drops, or
-restores either database, but it installs or migrates the Workhorse and demo schemas in both before
-the application becomes healthy. Database recovery belongs to the operator's private runbook.
+restores either database. Database recovery belongs to the operator's private runbook.
+
+## The schema step runs from the pipeline
+
+`.kamal/hooks/pre-deploy` runs the schema step. Kamal calls that hook after it builds and pushes the
+image and before it boots any container from it, which is the window the step belongs in: the
+database is ready for the new release before a process from that release exists.
+
+```sh
+bundle exec kamal app exec --version "$KAMAL_VERSION" "node dist/prepare-schema.js"
+```
+
+`kamal app exec` starts a new container from the version being deployed, with the role's
+environment and volumes, so the schema tool is the one inside the image that is about to serve
+traffic. Its version matches the application because it is the same image. That is the container
+form of the local-binary rule on the [installation page](https://workhorse.run/docs/installation).
+
+`dist/prepare-schema.js` installs or migrates the Workhorse schema and the demo's own tables in
+every configured workspace, then verifies each one with the checks the server makes at startup. It
+stands in for the documented `workhorse schema status --json` verification, because the demo has
+two databases and a second schema the CLI does not know about. A refusal exits non-zero, which
+fails the deploy before the container swap.
+
+Nothing prepares a schema at startup. The container entry point starts processes only, and the
+server asserts compatibility and refuses to open `/up` when the step did not run. That is
+deliberate: a component that migrated itself would be as many concurrent migrators as the
+deployment has nodes, which is why
+[ADR 0053](https://github.com/stablemates/workhorse/blob/main/docs/decisions/0053-start-migrations-at-0-1-0-and-keep-them-additive.md)
+makes migration a pipeline step. An installation that recreates a demo database must let this hook
+run before the new container starts, which a normal `kamal deploy` does.
+
+### The first installation needs one manual schema step
+
+Kamal writes each role's secret environment file to the host when it boots a container, and it runs
+`pre-deploy` before that. On every later deploy the file is already there, so the hook's container
+receives the database URLs. On the very first deploy the file does not exist yet, the hook's
+container cannot start, and the deploy stops before it boots anything.
+
+Install the schema once from the host before the first `scripts/setup-kamal.sh`, using the same
+image and the same command the hook runs, with the database URLs supplied however your installation
+supplies secrets to a one-off container. Every deploy after that is the hook alone.
 
 ## Adapting the examples
 

--- a/typescript/demo/DEPLOYMENT.md
+++ b/typescript/demo/DEPLOYMENT.md
@@ -119,13 +119,17 @@ restores either database. Database recovery belongs to the operator's private ru
 
 ## The schema step runs from the pipeline
 
-`.kamal/hooks/pre-deploy` runs the schema step. Kamal calls that hook after it builds and pushes the
+`.kamal/hooks/demo/pre-deploy` runs the schema step. Kamal calls that hook after it builds and pushes the
 image and before it boots any container from it, which is the window the step belongs in: the
 database is ready for the new release before a process from that release exists.
 
 ```sh
 bundle exec kamal app exec --version "$KAMAL_VERSION" "node dist/prepare-schema.js"
 ```
+
+Each application names its own hooks directory. Kamal's default is `.kamal/hooks` relative to the
+working directory, and both configs are deployed from the repository root, so an unqualified
+directory would run the demo's schema step during a site deploy.
 
 `kamal app exec` starts a new container from the version being deployed, with the role's
 environment and volumes, so the schema tool is the one inside the image that is about to serve

--- a/typescript/demo/container-entrypoint.mjs
+++ b/typescript/demo/container-entrypoint.mjs
@@ -1,25 +1,16 @@
 import { spawn } from "node:child_process";
 
-async function prepareSchema() {
-  const child = spawn(process.execPath, ["dist/prepare-schema.js"], {
-    env: process.env,
-    stdio: "inherit",
-  });
-  const code = await new Promise((resolve, reject) => {
-    child.once("error", reject);
-    child.once("exit", (exitCode, signal) => resolve(exitCode ?? (signal ? 1 : 0)));
-  });
-  if (code !== 0) throw new Error(`Demo schema preparation exited with code ${code}`);
-}
-
-try {
-  await prepareSchema();
-} catch (error) {
-  console.error("Could not prepare the demo schema", error);
-  process.exitCode = 1;
-}
-
-if (process.exitCode) process.exit();
+// This entry point starts processes and installs nothing.
+//
+// It used to run `dist/prepare-schema.js` first, which made every container its own migrator. That
+// is the one thing ADR 0053 rules out: no component migrates on start, because no component is a
+// singleton. The demo runs on one node today, so the old shape was harmless — and it was the
+// product's own showcase doing the opposite of what the product documents.
+//
+// The schema step now runs once from the deployment pipeline, in this same image, before any
+// container boots. `.kamal/hooks/pre-deploy` runs it. A deployment that skips it leaves the server
+// refusing to start with the message `assertSchemaCompatible` throws, which is the designed
+// failure rather than a surprise.
 
 const workerArguments = [
   "--require",

--- a/typescript/demo/src/prepare-schema.ts
+++ b/typescript/demo/src/prepare-schema.ts
@@ -1,10 +1,31 @@
-import { installSchema, migrateSchema, readSchemaVersion } from "@stablemates/workhorse";
+import {
+  assertSchemaCompatible,
+  installSchema,
+  migrateSchema,
+  readProtocolVersions,
+  readSchemaVersion,
+  WORKHORSE_SCHEMA_VERSION,
+} from "@stablemates/workhorse";
 import { Pool } from "pg";
-import { installDemoSchema } from "./app.js";
+import { assertDemoSchemaCompatible, installDemoSchema } from "./app.js";
 import { createDemoDatabase } from "./database.js";
 import { resolveDemoSchemaTargets } from "./environment.js";
 import { prepareSchema } from "./schema-preparation.js";
 
+/**
+ * The demo's schema step, run once from the deployment pipeline before any container starts.
+ *
+ * This is where the demo obeys the rule it documents. A migration is a pipeline step and no
+ * component migrates on start
+ * ([ADR 0053](../../../docs/decisions/0053-start-migrations-at-0-1-0-and-keep-them-additive.md)),
+ * so this program runs from `.kamal/hooks/pre-deploy` in the image being deployed, and the
+ * container entry point only starts processes.
+ *
+ * It also stands in for the `workhorse schema status --json` verification the installation page
+ * documents, because the demo has two databases and a second schema of its own. Preparing and then
+ * verifying both in one program means the deploy fails here, before a container boots, rather than
+ * on a health check that cannot say why.
+ */
 for (const target of resolveDemoSchemaTargets()) {
   const pool = new Pool({ connectionString: target.url, max: 1 });
   try {
@@ -14,7 +35,20 @@ for (const target of resolveDemoSchemaTargets()) {
       migrate: () => migrateSchema(pool),
       installDemo: () => installDemoSchema(createDemoDatabase(pool)),
     });
-    process.stdout.write(`Workhorse ${target.name} demo schema ${result} successfully.\n`);
+    // Verify what was just written with the same checks the application makes at startup. A
+    // failure here rejects the deployment; the same failure after the swap is an outage.
+    await assertSchemaCompatible(pool);
+    await assertDemoSchemaCompatible(createDemoDatabase(pool));
+    const installed = await readSchemaVersion(pool);
+    const served = await readProtocolVersions(pool);
+    process.stdout.write(
+      `Workhorse ${target.name} demo schema ${result} successfully. ${JSON.stringify({
+        installedVersion: installed,
+        expectedVersion: WORKHORSE_SCHEMA_VERSION,
+        servedProtocolVersions: served,
+        compatible: true,
+      })}\n`,
+    );
   } finally {
     await pool.end();
   }

--- a/typescript/demo/src/schema-preparation.test.ts
+++ b/typescript/demo/src/schema-preparation.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   prepareApplicationSchema,
@@ -135,5 +137,34 @@ describe("demo schema preparation", () => {
     expect(subject.install).not.toHaveBeenCalled();
     expect(subject.migrate).not.toHaveBeenCalled();
     expect(subject.installDemo).not.toHaveBeenCalled();
+  });
+});
+
+// ADR 0053 makes migration a pipeline step and forbids a component from migrating on start,
+// because no component is a singleton. The demo is the product's own showcase, so a container that
+// prepared its own schema would be the documentation contradicting itself in the one place a
+// reader can watch it run.
+describe("the demo's schema step runs from the pipeline", () => {
+  const repositoryRoot = resolve(import.meta.dirname, "../../..");
+
+  it("keeps schema preparation out of the container entry point", async () => {
+    const entrypoint = await readFile(
+      resolve(repositoryRoot, "typescript/demo/container-entrypoint.mjs"),
+      "utf8",
+    );
+    // The comment there names the file to say where the step went, so only code counts.
+    const code = entrypoint.replace(/^\s*\/\/.*$/gm, "");
+
+    expect(code).not.toContain("prepare-schema.js");
+  });
+
+  it("runs it from the pre-deploy hook, in the image being deployed", async () => {
+    const hook = await readFile(resolve(repositoryRoot, ".kamal/hooks/pre-deploy"), "utf8");
+
+    expect(hook).toContain("kamal app exec");
+    // Without the version, `kamal app exec` resolves an image from the deploying checkout's HEAD
+    // rather than the one this deploy built.
+    expect(hook).toContain('--version "$KAMAL_VERSION"');
+    expect(hook).toContain("node dist/prepare-schema.js");
   });
 });

--- a/typescript/demo/src/schema-preparation.test.ts
+++ b/typescript/demo/src/schema-preparation.test.ts
@@ -159,7 +159,7 @@ describe("the demo's schema step runs from the pipeline", () => {
   });
 
   it("runs it from the pre-deploy hook, in the image being deployed", async () => {
-    const hook = await readFile(resolve(repositoryRoot, ".kamal/hooks/pre-deploy"), "utf8");
+    const hook = await readFile(resolve(repositoryRoot, ".kamal/hooks/demo/pre-deploy"), "utf8");
 
     expect(hook).toContain("kamal app exec");
     // Without the version, `kamal app exec` resolves an image from the deploying checkout's HEAD


### PR DESCRIPTION
Closes [WH-608](https://ontrack.sh/projects/WH/issues/WH-608) on the public side. The matching
private operations change lands separately.

## The reported defect does not exist. A worse one does.

WH-608 said `prepareApplicationSchema` only asserts in production mode, so
`--recreate-demo-database` leaves the container asserting a schema that is not there. The first half
is true and the conclusion is not: `container-entrypoint.mjs` runs `dist/prepare-schema.js` before
it starts anything, regardless of mode, and that program installs or migrates both the Workhorse
schema and the demo's own tables. The reset path works, and `RUNBOOK.md`'s claim that the container
prepares both workspace schemas before it opens `/up` was accurate.

That is the actual problem. Every demo container is its own migrator, which is the one shape
[ADR 0053](https://github.com/stablemates/workhorse/blob/main/docs/decisions/0053-start-migrations-at-0-1-0-and-keep-them-additive.md)
rules out — no component migrates on start, because no component is a singleton. The demo runs on
one node, so it was harmless. It was also the product's own showcase doing the opposite of what the
product documents, in the one place a reader can watch it run, and the runbook could not cite
ADR 0053 while the demo contradicted it.

## The step moves to the pipeline

`.kamal/hooks/demo/pre-deploy` runs it, which Kamal calls after it builds and pushes the image and
before it boots any container from it:

```sh
bundle exec kamal app exec --version "$KAMAL_VERSION" "node dist/prepare-schema.js"
```

`kamal app exec` starts a new container from the version being deployed with the role's environment
and volumes, so the schema tool is the one inside the image about to serve traffic. Its version
matches the application because it is the same image — the container form of WH-605's local-binary
rule.

`prepare-schema.ts` now verifies as well as prepares. It re-reads each database with the same checks
the server makes at startup, so a refusal fails the deploy before the container swap instead of
appearing as a health check that cannot say why. It stands in for the documented
`workhorse schema status --json` step because the demo has two databases and a second schema the CLI
does not know about.

The entry point starts processes and installs nothing. A deployment that skips the step leaves the
server refusing to open `/up` with the sentence `assertSchemaCompatible` throws.

## Two things found while wiring it

**Hook collision.** Kamal resolves hooks from `.kamal/hooks` relative to the working directory, and
the demo and site configs are both deployed from the repository root. An unqualified hooks directory
would have run the demo's schema step during a site deploy. Each application now names its own.

**First installation.** Kamal uploads a role's secret environment file when it boots a container,
and runs `pre-deploy` before that. Every later deploy is fine; the very first has no file, so the
hook's container cannot start. Documented in `DEPLOYMENT.md` with the workaround rather than papered
over.

## Verification

`vitest run` 1690 passed across 140 files (was 1688; 2 new tests pin the entry point and the hook).
`typecheck`, `format:check`, and `lint` clean.

The schema step itself was run against two empty scratch databases:

```
Workhorse production demo schema installed successfully. {"installedVersion":1,...,"compatible":true}
Workhorse staging demo schema installed successfully.    {"installedVersion":1,...,"compatible":true}
```

Re-run on the same databases reported `migrated` and exited 0. Negative control: setting
`workhorse.protocol_version` to 2 so the schema no longer serves this client made it exit 1 with
`Workhorse schema serves SQL protocol 2 and no longer serves protocol 1 this runtime speaks.` The
scratch databases were dropped afterwards.

The command Kamal will build was printed from the real configuration through Kamal's own loader,
without deploying:

```
docker run --rm --name workhorse-demo-web-exec-… --network kamal
  --env WORKHORSE_DEMO_MODE="production" … --env-file .kamal/apps/workhorse-demo/env/roles/web.env
  --volume /var/run/postgresql:/var/run/postgresql:ro …
  <registry>/workhorse-demo:<version> node dist/prepare-schema.js
```

The socket is mounted, the secrets arrive through the env file rather than the command line, and the
image tag is the version being deployed. Hook resolution was checked the same way: the demo config
resolves `.kamal/hooks/demo` and finds `pre-deploy`; the site config resolves `.kamal/hooks/site` and
finds none.

https://claude.ai/code/session_01LbQjiy3riBwzkuXmReRNwb
