### PR TITLE
[WH-609] Give the public-beta notice one owner the packed smoke reads

### DIFF
--- a/scripts/public-beta-notice.ts
+++ b/scripts/public-beta-notice.ts
@@ -1,0 +1,37 @@
+/**
+ * The public-beta notice, owned once.
+ *
+ * Every public surface carries the notice, and more than one check reads it: this repository's
+ * Markdown and MDX surfaces are governed by `scripts/public-beta-release.test.ts`, and the copy
+ * inside each published tarball by `typescript/core/test/packed-packages.ts`. Restating the
+ * sentence in a second check is how the two came to assert notices that could not both exist, so
+ * both read this module instead.
+ *
+ * The notice is two durable facts wrapped in editorial prose. The label names the stability of the
+ * line. The compatibility boundary states the promise a reader upgrades on. The wording around
+ * them is free to change; a rewrite that drops either fact is the failure worth catching.
+ */
+
+/** The stability label every public surface carries. Compared without regard to case. */
+export const publicBetaLabel = "public beta";
+
+/** The compatibility promise the notice makes. Compared against {@link prose}. */
+export const compatibilityNotice = "inside a major line a migration only adds";
+
+/**
+ * Markdown prose, with blockquote markers and line wrapping removed.
+ *
+ * A surface may quote the notice, wrap it at any column, or reflow it. None of that changes the
+ * sentence, so compare what a reader reads.
+ */
+export function prose(contents: string): string {
+  return contents.replace(/^>\s?/gm, "").replace(/\s+/g, " ");
+}
+
+/** Whether `contents` carries the public-beta notice: the label and the compatibility boundary. */
+export function hasPublicBetaNotice(contents: string): boolean {
+  return (
+    contents.toLowerCase().includes(publicBetaLabel) &&
+    prose(contents).includes(compatibilityNotice)
+  );
+}

--- a/scripts/public-beta-release.test.ts
+++ b/scripts/public-beta-release.test.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { publishedPackages, repositoryRoot } from "./packages.js";
+import { compatibilityNotice, prose, publicBetaLabel } from "./public-beta-notice.js";
 
 /** The release this repository cuts next: one version on npm, PyPI, and Go from one commit. */
 const releaseVersion = "0.1.0";
@@ -17,9 +18,6 @@ const npmSourceCommit = "856cdcf354aa83a3acf8ee67043145adb9c99e09";
 const pythonSourceCommit = "663c526805746786f12b3be3e151e8ce06c80057";
 const goSourceCommit = "dbd5437362930f712157ffcc72c3296e971e4f5a";
 
-const betaLabel = "public beta";
-const compatibilityNotice = "inside a major line a migration only adds";
-
 interface SupportManifest {
   readonly support: {
     readonly go: { readonly minimum: string };
@@ -31,10 +29,6 @@ interface SupportManifest {
 
 async function read(relativePath: string): Promise<string> {
   return readFile(path.join(repositoryRoot, relativePath), "utf8");
-}
-
-function prose(contents: string): string {
-  return contents.replace(/^>\s?/gm, "").replace(/\s+/g, " ");
 }
 
 /** One `## version — date` entry of a changelog, up to the next `##` heading. */
@@ -56,7 +50,7 @@ describe("the 0.1.0 release", () => {
         version?: string;
       };
       expect(manifest.version).toBe(releaseVersion);
-      expect(manifest.description?.toLowerCase()).toContain(betaLabel);
+      expect(manifest.description?.toLowerCase()).toContain(publicBetaLabel);
       const workhorsePeer = manifest.peerDependencies?.["@stablemates/workhorse"];
       expect([undefined, corePeerRange]).toContain(workhorsePeer);
     }
@@ -72,7 +66,7 @@ describe("the 0.1.0 release", () => {
     const pythonManifest = await read("python/pyproject.toml");
     expect(pythonManifest).toContain(`version = "${releaseVersion}"`);
     expect(pythonManifest).toContain("Development Status :: 4 - Beta");
-    expect(pythonManifest.toLowerCase()).toContain(betaLabel);
+    expect(pythonManifest.toLowerCase()).toContain(publicBetaLabel);
     expect(await read("python/uv.lock")).toContain(
       `name = "stablemates-workhorse"\nversion = "${releaseVersion}"`,
     );
@@ -131,9 +125,22 @@ describe("the public beta line", () => {
 
     for (const relativePath of readmes) {
       const contents = await read(relativePath);
-      expect(contents.toLowerCase()).toContain(betaLabel);
+      expect(contents.toLowerCase()).toContain(publicBetaLabel);
       expect(prose(contents)).toContain(compatibilityNotice);
     }
+  });
+
+  /**
+   * The packed smoke checks the notice inside each tarball, so it needs the same definition these
+   * tests use. It used to restate the sentence, and the two drifted the moment the wording changed:
+   * the packed job runs on the daily cron rather than on a pull request, so five green pull requests
+   * shipped a notice it still rejected. This keeps it a reader of the notice, not a second author.
+   */
+  it("keeps the packed smoke a reader of the notice rather than a second author of it", async () => {
+    const packedSmoke = await read("typescript/core/test/packed-packages.ts");
+    expect(packedSmoke).toContain('from "../../../scripts/public-beta-notice.js"');
+    expect(packedSmoke).not.toContain("**Public beta:**");
+    expect(prose(packedSmoke)).not.toContain(compatibilityNotice);
   });
 
   it("labels public surfaces and keeps the compatibility boundary in durable documentation", async () => {
@@ -150,7 +157,7 @@ describe("the public beta line", () => {
 
     for (const relativePath of surfaces) {
       const contents = await read(relativePath);
-      expect(contents.toLowerCase()).toContain(betaLabel);
+      expect(contents.toLowerCase()).toContain(publicBetaLabel);
     }
     const compatibilitySurfaces = [
       "README.md",

--- a/typescript/core/test/packed-packages.ts
+++ b/typescript/core/test/packed-packages.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { publishedPackages, workspacePackages } from "../../../scripts/packages.js";
+import { hasPublicBetaNotice } from "../../../scripts/public-beta-notice.js";
 import { WORKHORSE_SCHEMA_VERSION } from "../src/schema.js";
 
 const exec = promisify(execFile);
@@ -130,14 +131,6 @@ try {
     if (!entry) throw new Error(`${name} is not a published package`);
     return path.join(tarballs, entry.tarball);
   };
-  const betaNotice =
-    "> **Public beta:** Workhorse is usable for evaluation and early production adoption, but 0.x minor\n" +
-    "> releases may break compatibility, including the schema. There is no upgrade path between 0.x\n" +
-    "> releases; ordered migrations begin at 1.0.0.";
-  const repositoryReadme = await readFile(path.join(repository, "README.md"), "utf8");
-  if (!repositoryReadme.includes(betaNotice)) {
-    throw new Error("The repository README does not contain the canonical public beta notice");
-  }
   const repositoryLicense = await readFile(path.join(repository, "LICENSE"));
   const repositoryNotice = await readFile(path.join(repository, "NOTICE"));
   for (const entry of published) {
@@ -146,8 +139,8 @@ try {
     await run("tar", ["-xzf", tarballFor(entry.name), "-C", releaseExtracted]);
     const packageRoot = path.join(releaseExtracted, "package");
     const readme = await readFile(path.join(packageRoot, "README.md"), "utf8");
-    if (!readme.includes(betaNotice)) {
-      throw new Error(`${entry.name} README does not contain the canonical public beta notice`);
+    if (!hasPublicBetaNotice(readme)) {
+      throw new Error(`${entry.name} README does not carry the public beta notice`);
     }
     const packageLicense = await readFile(path.join(packageRoot, "LICENSE"));
     if (!packageLicense.equals(repositoryLicense)) {


### PR DESCRIPTION
`pnpm test:packed` fails on `main`. The packed smoke pinned the public-beta notice as a literal blockquote; WH-604 rewrote that sentence on every surface and repointed `scripts/public-beta-release.test.ts` at the new wording. The two checks then asserted notices that could not both exist, and the smoke failed at `The repository README does not contain the canonical public beta notice` before reaching a tarball. That blocks the 0.1.0 release workflow, which runs `pnpm npm:test:packed`.

Nothing caught it because the `packed install` job runs on the daily cron, not on pull requests. Five consecutive pull requests changed release-governed text and none exercised the check that guards it.

## What changed

- `scripts/public-beta-notice.ts` now owns the notice: the label, the compatibility boundary, the prose normalisation both checks need, and the predicate that joins them. The notice is two durable facts wrapped in editorial prose, so the module compares the facts and lets the wording move.
- The packed smoke reads that module for the README inside each tarball, and drops its own copy of the repository README check. That assertion is about source-tree text, which `scripts/public-beta-release.test.ts` already owns and runs on every pull request; the packed job keeps only the questions that need a tarball.
- A guard in `scripts/public-beta-release.test.ts`, in the idiom `published-packages.test.ts` already uses for consumers of the derived package list, fails if the packed smoke ever restates the sentence instead of importing it. Verified by reintroducing a literal: the guard fails.

## Pull-request coverage

The packed job's trigger does not change. A 40-minute packed install on every pull request buys nothing the unit job cannot assert, and ADR 0043 puts it on the daily cron deliberately. What was missing was the shared definition, which now fails in the unit job the moment a surface drops either fact.

## Retired wording

Two copies remain, both quotations inside decision records, neither a check. ADR 0042 is already marked amended by ADR 0053. ADR 0046 quotes it inside a README prototype it introduces as deliberately rough prose whose decision is ownership and order.

## Verification

`pnpm test:packed`, the full unit suite (1073 tests), `pnpm lint`, and `pnpm typecheck` all pass locally.

https://claude.ai/code/session_01HwzCcUda5WTuTLrxnubc2u