### PR TITLE
[WH-613] Give the published Compatibility page all four runtimes and a guard

### DIFF
--- a/site/content/docs/compatibility.mdx
+++ b/site/content/docs/compatibility.mdx
@@ -1,23 +1,35 @@
 ---
 title: Compatibility
-description: Node.js 22+, PostgreSQL 15+, no extensions, and an exact-match schema — what is tested and what that means.
+description: The tested runtimes and database versions for all three SDKs, what "supported" proves, and how a client and an installed schema agree.
 ---
 
 You need to know two things before adopting a queue: will it run on your stack, and what does
-"supported" actually prove. Workhorse requires Node.js 22 or newer and PostgreSQL 15 or newer, and
-a version counts as supported only when continuous integration runs the full suite against it on
-every change. Workhorse may run elsewhere, but untested versions do not carry the same correctness
-evidence.
+"supported" actually prove. Workhorse ships three SDKs — TypeScript, Python, and Go — over one
+PostgreSQL schema. A version counts as supported only when continuous integration runs the full
+suite against it. Workhorse may run elsewhere, but untested versions do not carry the same
+correctness evidence.
 
 ## The tested matrix
 
-CI exercises every combination of Node.js 22 and 24 with PostgreSQL 15, 16, 17, and 18. The
-runtime exports the same boundary to tooling: `MINIMUM_NODE_MAJOR` is 22, `MINIMUM_POSTGRES_MAJOR`
-is 15, and `SUPPORTED_NODE_MAJORS` and `SUPPORTED_POSTGRES_MAJORS` list the CI majors. A test in
-the repository fails whenever the CI matrix, the package `engines` fields, and these constants
-drift apart, so the published numbers are always the exercised numbers. The
-[compatibility matrix](https://github.com/stablemates/workhorse/blob/main/docs/compatibility.md)
-tracks them as they change.
+| Runtime    | Supported      | Minimum | Notes                                                   |
+| ---------- | -------------- | ------- | ------------------------------------------------------- |
+| Node.js    | 22, 24         | 22      | Even-numbered releases only. `engines.node` is `>=22`.  |
+| Python     | 3.12–3.14      | 3.12    | `stablemates-workhorse` ships one `py3-none-any` wheel. |
+| Go         | 1.25 and newer | 1.25    | The module pins pgx v5.9.2.                             |
+| PostgreSQL | 15, 16, 17, 18 | 15      | No extension beyond the default `plpgsql` is installed. |
+
+Your application needs one of those language runtimes and a PostgreSQL server at or above its
+minimum. It does not need all three: a Python or Go service runs on Python or Go alone. Node.js
+appears in one other place, and only one — the machine that runs your deployment's schema step,
+because schema tooling ships in the TypeScript package.
+
+Pull requests and pushes exercise the newest version of each language against the newest PostgreSQL
+for fast feedback. The weekly schedule runs every combination in the table. A regression on any of
+them is a release blocker. The runtime also exports the boundary to tooling, so a script can read it
+rather than parse this page: `MINIMUM_NODE_MAJOR`, `MINIMUM_POSTGRES_MAJOR`,
+`SUPPORTED_NODE_MAJORS`, and `SUPPORTED_POSTGRES_MAJORS`. A test in the repository fails whenever
+the CI matrix, the package `engines` fields, these constants, and this table drift apart, so the
+published numbers are always the exercised numbers.
 
 You can classify a connected server at runtime. `readPostgresSupport` reports whether it is tested,
 merely newer than tested, or below the minimum; `assertSupportedPostgres` refuses to proceed below
@@ -40,41 +52,63 @@ Workhorse requires only stock PostgreSQL with its default procedural language. I
 extension, so it runs on managed services — RDS, Cloud SQL, Neon, Supabase — without an allowlist
 conversation.
 
-Published packages are ESM with TypeScript declarations. Plain JavaScript uses the same runtime;
-CommonJS loading is outside the supported package format.
+Published TypeScript packages are ESM with TypeScript declarations. Plain JavaScript uses the same
+runtime; CommonJS loading is outside the supported package format.
 
-## Match the schema exactly
+## Schema tooling ships in the TypeScript package
 
-The PostgreSQL schema is the durable protocol. The application runtime and the installed schema
-must agree exactly, because mismatched workers could interpret lifecycle state differently.
+Every SDK reads and writes the schema, but only `@stablemates/workhorse` installs and migrates it.
+`workhorse schema install`, `workhorse schema migrate`, and `workhorse schema status` are commands
+of that package, and a Python or Go deployment runs them with `npx` at the SDK version its
+application depends on. That is why the machine running your deployment needs Node.js even when your
+application does not.
 
-Call `assertSchemaCompatible` during startup. A mismatch should fail the process before it claims
-or changes work.
+This is a decision rather than a missing feature. Migration is the most safety-critical code in the
+project, so it exists once rather than three times, and it runs as one deliberate deployment step
+rather than from processes that deploy on many nodes. [Installation](/docs/installation) gives both
+command forms, and [Limitations](/docs/limitations) states the boundary alongside the others.
 
-Use `installSchema` for a fresh database and `migrateSchema` for an installed schema. The migration
-entrypoint applies immutable, forward-only steps from the supported baseline and refuses missing,
-older-than-baseline, or newer schemas before changing them. Each step commits one version in its
-own transaction behind an advisory lock and rolls back atomically on failure. Development schemas
-at versions retired before the baseline still require a reset.
+## A client accepts its own schema version and newer
 
-The dashboard transport has its own `dashboard/v1` contract. TypeScript, Python, and Go backends
-use its shared procedure schemas, HTML placeholders, request order, and HTTP fixtures. Embed a
-shipped backend for operator access; use `Queue` for application operations and `Admin` for
-operator integrations.
+The PostgreSQL schema is the durable protocol between every process that touches the queue. A client
+accepts the schema version it was built against and every later version inside the same major line,
+because a migration inside a major line only adds: it may add a function, view, column, table, or
+index, and it supersedes a function by adding a new one beside it. A client refuses an installed
+schema below its floor, and refuses one at or beyond the next major boundary.
+
+That floor with no ceiling inside a major line is what makes a rolling upgrade work. Your pipeline
+migrates first, every still-running process keeps working because the schema only grew, and the new
+release rolls out at its own pace.
+
+Assert compatibility when a process starts, before it claims or changes work:
+`assertSchemaCompatible` in TypeScript, `assert_schema_compatible` in Python, and
+`AssertCompatible` in Go. [Installation](/docs/installation) shows each call and the errors a
+refusal raises.
+
+`workhorse schema migrate` applies immutable, forward-only steps from the supported baseline. Each
+step commits one version in its own transaction behind an advisory lock and rolls back atomically on
+failure. Development schemas at versions retired before the baseline have no migration history and
+still require a reset.
+
+## One protocol across the three SDKs
 
 Python and Go use the versioned SQL functions and JSON fixtures under `protocol/v1/` as their
 compatibility boundary. The fixtures require both clients to reject an incompatible schema or
 protocol before mutation, then verify canonical requests, results, transitions, and structured
 errors.
 
-The Python `stablemates-workhorse` package supports Python 3.12 through 3.14. It uses Psycopg synchronously
-or asynchronously and asyncpg asynchronously. Every worker runtime delegates cron evaluation to
-the versioned PostgreSQL functions and each definition's stored IANA timezone. Its release test
-installs the built wheel and source distribution bare, with the compatibility `psycopg` extra, and
-with the `asyncpg` extra. It runs the public examples and checks the active Python and PostgreSQL
-versions against the declared matrix. The package version floats
-independently from the TypeScript packages because schema and SQL protocol versions define their
-compatibility.
+The dashboard transport has its own `dashboard/v1` contract. TypeScript, Python, and Go backends
+use its shared procedure schemas, HTML placeholders, request order, and HTTP fixtures. Embed a
+shipped backend for operator access; use `Queue` for application operations and `Admin` for
+operator integrations.
+
+The Python `stablemates-workhorse` package uses Psycopg synchronously or asynchronously and asyncpg
+asynchronously. Every worker runtime delegates cron evaluation to the versioned PostgreSQL functions
+and each definition's stored IANA timezone. Its release test installs the built wheel and source
+distribution bare, with the compatibility `psycopg` extra, and with the `asyncpg` extra. It runs the
+public examples and checks the active Python and PostgreSQL versions against the declared matrix.
+The package version floats independently from the TypeScript packages because schema and SQL
+protocol versions define their compatibility.
 
 ## Bun and Deno
 
@@ -98,8 +132,8 @@ changes and the schema version each release requires.
 Every release publishes one version to npm, PyPI, and the Go module proxy from one source commit.
 The current release is `0.1.0`. Earlier beta versions stay on the registries, and each changelog
 dates them and names their source commits. Any 0.x minor release may change behaviour, so read the
-changelog before you upgrade. The schema upgrades in place: a release ships ordered migrations, and
-inside a major line a migration only adds.
+changelog before you upgrade. It will not ask you to recreate your database: the schema upgrades in
+place, because a release ships ordered migrations and a migration inside a major line only adds.
 
 The dashboard and core may use different patch releases within the same minor line. The dashboard
 server reads core-owned versioned views and functions, so a core patch remains compatible when its
@@ -120,11 +154,10 @@ trusted publishing uploads the unchanged files and attestations.
 The Go module records independent versions in `go/CHANGELOG.md`. The repository release script
 runs the full gate before it creates and pushes the matching `go/vX.Y.Z` tag.
 
-GitHub Actions remain disabled while the repository is private, so these release paths are defined
-but must not run until that restriction is lifted. Once public, pull requests and pushes run the
-newest supported versions, the weekly schedule runs the full compatibility matrix, and the daily
-schedule verifies packed installs. Branch protection requires the stable `CI / required` check,
-and protected npm and PyPI environments require a second person to approve publication.
+The repository is public and these paths run. Pull requests and pushes to `main` run the newest
+supported versions, the weekly schedule runs the full compatibility matrix, and the daily schedule
+verifies packed installs. Branch protection requires the stable `CI / required` check, and protected
+npm and PyPI environments require a second person to approve publication.
 
 One honest caveat: support proves correctness under the tested matrix. It does not promise a
 throughput level for your database, payloads, handlers, or deployment topology.

--- a/site/content/docs/limitations.mdx
+++ b/site/content/docs/limitations.mdx
@@ -81,9 +81,10 @@ business writes lives.
 versions retired before that baseline have no migration history, so operators must reset those
 development schemas instead of upgrading them.
 
-Workaround: keep schema changes in the deployment path and call `migrateSchema` — or
-`workhorse schema migrate` — before starting a new runtime. The changelog records each release's
-required schema version.
+Workaround: keep schema changes in the deployment path and run `workhorse schema migrate` — the
+command every language uses — before starting a new runtime. TypeScript applications that prefer to
+drive it in code can call `migrateSchema` instead. The changelog records each release's required
+schema version.
 
 ## Dashboard authentication has one built-in role
 

--- a/site/content/docs/operations.mdx
+++ b/site/content/docs/operations.mdx
@@ -13,6 +13,13 @@ page is the map, plus the fleet controls that belong to no single sibling.
 readiness and liveness probes, and database pool ownership. Deploy workers there first; every
 other concern assumes a supervised process already exists.
 
+## Schema installation and migration
+
+[Installation](/docs/installation) owns the schema step. It is a deployment step, run once from your
+pipeline before any process from the new release starts, never from an application or worker on
+startup. [Compatibility](/docs/compatibility) explains why a migrated database keeps the previous
+release running while the new one rolls out.
+
 ## Database maintenance
 
 [Maintenance and retention](/docs/maintenance) owns promotion, expired-lease recovery, history

--- a/typescript/core/test/site-guide-coverage.test.ts
+++ b/typescript/core/test/site-guide-coverage.test.ts
@@ -104,6 +104,10 @@ describe("documentation site guide coverage", () => {
     expect(files[4]).toContain("pending [keyed debounce]");
     expect(files[2]).toContain("calls `expire_owned_v1`");
     expect(files[6]).toContain("calls `expire_owned_v1`");
-    expect(files[7]).toContain("Call `assertSchemaCompatible` during startup");
+    // Compatibility used to name the TypeScript entrypoint alone, which read as a TypeScript-only
+    // instruction on a page three SDKs share. It now names all three, so what this holds is the
+    // claim rather than the spelling: the page still tells a reader to assert before a process
+    // works. support-matrix.test.ts holds the three entrypoint names.
+    expect(files[7]).toContain("Assert compatibility when a process starts");
   });
 });

--- a/typescript/core/test/support-matrix.test.ts
+++ b/typescript/core/test/support-matrix.test.ts
@@ -453,23 +453,28 @@ describe("documentation", () => {
       .find((line) => line.startsWith("require github.com/jackc/pgx/v5 "))
       ?.split(" ")
       .at(-1);
-    expect(supportTable["Node.js"]).toMatchObject({
-      Supported: claimedNodeMajors,
-      Minimum: String(manifest.support.node.minimum),
-    });
-    expect(supportTable.Python).toMatchObject({
-      Supported: `${pythonTested[0]}–${pythonTested.at(-1)}`,
-      Minimum: manifest.support.python.minimum,
-    });
-    expect(supportTable.Go).toMatchObject({
-      Supported: `${goMinimum} and newer`,
-      Minimum: goMinimum,
-      Notes: `The module pins pgx ${pgxVersion}.`,
-    });
-    expect(supportTable.PostgreSQL).toMatchObject({
-      Supported: claimed,
-      Minimum: String(manifest.support.postgres.minimum),
-    });
+    // The published page carries the same four rows as the reference rather than deferring to it,
+    // because a reader deciding whether to adopt should not have to open a Markdown file on GitHub
+    // to learn whether their Python version is supported. Both tables are asserted from the same
+    // expectation, so the two layers cannot state different numbers.
+    const siteTable = markdownTable(sitePage, "## The tested matrix");
+    const expectedSupport = {
+      Go: { Supported: `${goMinimum} and newer`, Minimum: goMinimum },
+      "Node.js": {
+        Supported: claimedNodeMajors,
+        Minimum: String(manifest.support.node.minimum),
+      },
+      PostgreSQL: { Supported: claimed, Minimum: String(manifest.support.postgres.minimum) },
+      Python: {
+        Supported: `${pythonTested[0]}–${pythonTested.at(-1)}`,
+        Minimum: manifest.support.python.minimum,
+      },
+    } satisfies Record<string, { Supported: string; Minimum: string }>;
+    for (const [runtime, cells] of Object.entries(expectedSupport)) {
+      expect(supportTable[runtime]).toMatchObject(cells);
+      expect(siteTable[runtime]).toMatchObject(cells);
+    }
+    expect(supportTable.Go).toMatchObject({ Notes: `The module pins pgx ${pgxVersion}.` });
     for (const sdkReadme of [coreReadme, pythonReadme, goReadme]) {
       const sections = [
         "## Install",
@@ -507,15 +512,9 @@ describe("documentation", () => {
     expect(sitePage).toContain(
       "https://github.com/stablemates/workhorse/blob/main/docs/compatibility.md",
     );
-    expect(sitePage).not.toContain(claimed);
-    expect(sitePage).not.toContain(claimedNodeMajors);
     expect(installation).toContain("[Compatibility](/docs/compatibility)");
-    // Installation links to Compatibility rather than restating a floor, so raising one in
-    // support.json needs no edit here. What is forbidden is the shape, not the value: the page
-    // states no supported version, so `Node.js 20` is as much a restatement as `Node.js 22`, and
-    // a rule built from the current floor would only ever catch the number that is right. The
-    // runtime names come from the manifest's own keys, so a newly supported runtime fails here
-    // until it is brought under the same rule.
+    // The runtime names come from the manifest's own keys, so a newly supported runtime fails here
+    // until it is given a row on both tables and brought under the restatement rule below.
     const runtimeNames = {
       go: "Go",
       node: "Node.js",
@@ -523,9 +522,38 @@ describe("documentation", () => {
       python: "Python",
     } satisfies Record<keyof SupportManifest["support"], string>;
     expect(Object.keys(runtimeNames).toSorted()).toEqual(Object.keys(manifest.support).toSorted());
+    expect(Object.keys(expectedSupport).toSorted()).toEqual(Object.values(runtimeNames).toSorted());
+    // Every version on Compatibility belongs to its table, where the assertions above hold it to
+    // support.json. Prose on that page evades those assertions, which is how "Node.js 22 and 24
+    // with PostgreSQL 15, 16, 17, and 18" outlived the matrix it restated, so the shape is
+    // forbidden outside the table rather than any particular value. Installation carries the same
+    // rule throughout, because it links to Compatibility instead of restating a floor.
+    const sitePageProse = sitePage
+      .split("\n")
+      .filter((line) => !line.startsWith("|"))
+      .join("\n");
     for (const name of Object.values(runtimeNames)) {
-      expect(installation).not.toMatch(new RegExp(`${name.replaceAll(".", "\\.")}\\s\\d`));
+      const restatement = new RegExp(`${name.replaceAll(".", "\\.")}\\s\\d`);
+      expect(installation).not.toMatch(restatement);
+      expect(sitePageProse).not.toMatch(restatement);
     }
+    // The model is a floor with no ceiling inside a major line, so the page must not promise the
+    // exact match or the refusal of a newer schema that ADR 0053 replaced.
+    expect(sitePage).not.toMatch(/schema must agree exactly|exact-match schema/);
+    expect(sitePage).not.toContain("or newer schemas");
+    // Schema tooling ships only in the TypeScript package, and the page that states the support
+    // boundary is where a Python or Go reader learns their deployment machine needs Node.js.
+    expect(sitePage).toContain("## Schema tooling ships in the TypeScript package");
+    for (const entrypoint of [
+      "assertSchemaCompatible",
+      "assert_schema_compatible",
+      "AssertCompatible",
+    ]) {
+      expect(sitePage).toContain(entrypoint);
+    }
+    // The repository is public and its workflows run. A page that says otherwise tells a reader
+    // the release paths they can see running are forbidden to run.
+    expect(sitePage).not.toContain("while the repository is private");
     // The smoke tier is a weaker claim than support, and both layers must state it as such: the
     // reference names each runtime's tier section, and the site page describes it without pinning
     // versions it does not test.


### PR DESCRIPTION
Closes WH-613.

## The problem

`site/content/docs/compatibility.mdx` read as a Node-only product and restated
claims the product had retired:

1. The frontmatter and opening required Node.js of every reader. False for a
   Python or Go application — only the machine that runs the schema CLI needs it.
2. The tested matrix listed Node.js against PostgreSQL. Go's floor appeared
   nowhere; Python's sat four sections below, inside a paragraph about release
   testing.
3. "Match the schema exactly" promised the opposite of ADR 0053, which replaced
   the exact match with a floor and no ceiling inside a major line.
4. The migration entrypoint no longer refuses a newer schema, and the page did
   not say schema tooling is TypeScript-only.
5. "GitHub Actions remain disabled while the repository is private" — the
   repository is public and CI runs on every pull request.

The guard in `support-matrix.test.ts` asserted the page did not contain
`15, 16, 17, 18` or `22, 24`. The page wrote "Node.js 22 and 24 with PostgreSQL
15, 16, 17, and 18", a spelling neither rule recognised, so it restated the
matrix with nothing keeping the restatement honest.

## The decision

Option B from the Issue: the page carries the matrix rather than deferring to a
Markdown file on GitHub. `installation.mdx` already promises the reader that
Compatibility names every supported version, and someone deciding whether to
adopt should not leave the site to learn whether their Python version is
supported.

## What changed

- **`compatibility.mdx`** opens on three SDKs over one schema, carries the same
  four rows as `docs/compatibility.md`, and says which runtimes an application
  actually needs. A new *Schema tooling ships in the TypeScript package* section
  is where the deployment machine's Node.js requirement now lives. *Match the
  schema exactly* becomes *A client accepts its own schema version and newer*,
  naming `assertSchemaCompatible`, `assert_schema_compatible`, and
  `AssertCompatible`. The CI paragraph states that the repository is public.
- **`support-matrix.test.ts`** asserts both tables from one expectation, so the
  reference and the published page cannot state different numbers, and forbids a
  version restatement in the page's prose the way `installation.mdx` is already
  held. A runtime added to `support.json` fails until it has a row on both
  tables. Retired claims are asserted absent by shape rather than by wording.
- **`limitations.mdx`** leads its workaround with `workhorse schema migrate` and
  offers `migrateSchema` second.
- **`operations.mdx`** gains the schema step its map of concerns was missing.
  (The Issue left this one to decide: it is a map page that names the owner of
  each concern, and the schema step had no entry.)
- **`site-guide-coverage.test.ts`** held the page to the TypeScript-only
  sentence that section replaced; it now holds the claim rather than the
  spelling.

## Verification

- `pnpm exec vitest run typescript/core/test/support-matrix.test.ts` — 40 passed.
  Negative-tested three ways, each failing as intended: a drifted table cell, a
  prose restatement of the old spelling, and a deleted runtime row.
- `pnpm test` — 1691 tests, all passing after `pnpm build:runtime:dev` (the four
  pre-existing failures in `typescript/demo/src/telemetry.test.ts` were a missing
  `workhorse-otel` build in this worktree, not this change).
- `pnpm docs:build`, `pnpm lint`, `pnpm typecheck`, `oxfmt --check`, and the site
  smoke — all green.

https://claude.ai/code/session_01Ga2NCCYcMXtziyYciKXaxW
