### PR TITLE
[WH-610] Run the documented schema command in the packed consumer smoke

### DIFF
--- a/typescript/core/test/packed-packages.ts
+++ b/typescript/core/test/packed-packages.ts
@@ -271,6 +271,49 @@ try {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
 
+  // Every TypeScript surface tells a reader to install the schema with
+  // `npm exec --no -- workhorse schema install`, on the strength of one property: the binary
+  // resolves from the project's own node_modules, so its version matches the application by
+  // construction. Declaring the binary in the manifest is a different thing from having it. The
+  // package manager builds the shim at install time and skips it when the target file is missing,
+  // so run the resolution the documented command performs and read back the version it prints.
+  const packedVersion = corePackage.version;
+  if (typeof packedVersion !== "string") {
+    throw new TypeError("The packed core package declares no version");
+  }
+  const resolvedVersion = (
+    await run("npm", ["exec", "--no", "--", "workhorse", "--version"], coreOnlyConsumer)
+  ).trim();
+  if (resolvedVersion !== packedVersion) {
+    throw new Error(
+      `The documented command printed ${resolvedVersion}; the packed core package is ${packedVersion}`,
+    );
+  }
+
+  // `--no` is what keeps that resolution honest. Outside a project that depends on Workhorse there
+  // is no such binary, and npm must refuse rather than install and run whatever the public registry
+  // happens to publish under the name `workhorse`.
+  const outsideConsumer = path.join(scratch, "outside-consumer");
+  await mkdir(outsideConsumer);
+  let unguarded: string | undefined;
+  try {
+    unguarded = await run("npm", ["exec", "--no", "--", "workhorse", "--version"], outsideConsumer);
+  } catch (error) {
+    // A numeric code is a non-zero exit, which is the refusal. A string code is npm itself failing
+    // to start, which is not.
+    if (typeof (error as NodeJS.ErrnoException).code !== "number") throw error;
+  }
+  if (unguarded !== undefined) {
+    throw new Error(
+      `"npm exec --no" ran a workhorse binary outside a consumer project and printed ${unguarded.trim()}`,
+    );
+  }
+  // The pinned form a Python or Go pipeline runs,
+  // `npx --package @stablemates/workhorse@<version> workhorse schema install`, is not covered here.
+  // npx resolves the whole dependency tree from the registry and offers no override for a nested
+  // edge, so it cannot be pointed at the tarballs under test. Verify that form against the registry
+  // after publishing.
+
   const dashboardExtracted = path.join(scratch, "dashboard");
   await mkdir(dashboardExtracted);
   await run("tar", ["-xzf", dashboardTarball, "-C", dashboardExtracted]);


### PR DESCRIPTION
`npm exec --no -- workhorse schema install` is what every TypeScript surface tells a reader to run.
WH-605 chose it for one property: the binary resolves from the project's own `node_modules`, so its
version matches the application by construction. Nothing tested that it resolves.

`typescript/core/test/packed-packages.ts` asserted the packed manifest declares the binary. That is
a different thing from having it — pnpm builds the shim at install time and skips it when the target
file is missing, which the demo image build logs on every run.

## What this adds

- The core-only consumer runs `npm exec --no -- workhorse --version` and checks the version against
  the packed package. Deleting the shim from that consumer makes the assertion fail, which is the
  regression it guards.
- A second consumer directory, outside any install, covers what `--no` is for: npm refuses rather
  than installing and running whatever the public registry publishes under the name `workhorse`.
  Verified: `npm exec --no -- cowsay --version` in an empty directory reports `npx canceled due to
  missing packages and no YES option`, so the refusal holds regardless of what the remote package
  contains.

## What it deliberately leaves out

The pinned `npx --package @stablemates/workhorse@<version> workhorse schema install` form that a
Python or Go pipeline runs. npx resolves the whole dependency tree from the registry and has no
equivalent of pnpm's `overrides`, so it cannot be pointed at the tarballs under test: against the
local tarball it fails with `ETARGET No matching version found for
@stablemates/workhorse-dashboard-contract@0.1.0`. There is also no offline path, since npx resolves
the specifier over the network first. A comment in the test records this; verifying that form needs
published artifacts.

By contrast the TypeScript form needs no network at all. Under an unreachable registry
(`npm_config_registry=http://127.0.0.1:1/`), `npm exec --no -- workhorse --version` inside the
consumer still printed `0.1.0`.

## Verification

`pnpm test:packed` passes end to end: `Packed core, ORM providers, and dashboard consumer tests
passed.`

https://claude.ai/code/session_01KWXoMXHpQRqo43jbFKSPQ1
