### PR TITLE
[WH-569] Re-cut the 0.1.0 candidate on the release notes it now needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,24 @@ and 24 and PostgreSQL 15 through 18.
   of the `0.x` line and is removed in `1.0.0`. `MaintenanceLoopCadences` is unchanged, because
   Python and Go share that name.
 
+- **A client declares a schema floor and no ceiling, and the database declares which clients it
+  still serves.** The startup check refused any schema newer than the version the build was
+  compiled against, which would have turned the first in-place migration into an outage for the
+  length of a rolling deployment. A build cannot know which later release stops serving it, so the
+  ceiling comes from the database instead: `workhorse.protocol_version` records the SQL protocol
+  versions the installed schema still serves, and a client whose protocol is absent from that list
+  refuses. Below the oldest served version is `schema-too-new`; above the newest is
+  `schema-too-old`. A schema that records nothing enforces nothing. `readProtocolVersions` reports
+  the list, and the Python and Go checks read the same rows.
+- **The standalone dashboard server sets browser protections, because it owns its whole origin.**
+  Every response from `startDashboardServer` now carries `Content-Security-Policy`,
+  `X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`, and `X-Robots-Tag`, and no
+  response references a remote origin. `createDashboardHost` still sets none: an embedded host
+  shares the application's origin, and two `Content-Security-Policy` headers on one response
+  intersect rather than override, so a policy set here could quietly narrow an application that
+  already has a stricter one. The dashboard-server README, the authentication guide, and the
+  dashboard page on the site print the policy an embedder copies.
+
 ### Added
 
 - `SchemaCompatibilityError` is exported from `@stablemates/workhorse`. `assertSchemaCompatible`
@@ -156,6 +174,36 @@ and 24 and PostgreSQL 15 through 18.
   `workhorse` binary owns. Neither flag changed; they were previously visible only in
   `workhorse init --help`.
 
+- **The `workhorse admin` CLI covers every operator action that previously needed a browser.**
+  `admin purge <queue>` joins cancel, redrive, pause, and resume as a guarded command, and
+  `admin pause-worker <worker-id>` and `admin resume-worker <worker-id>` take one worker out of
+  rotation and put it back. All three demand `--env` naming the connected database, then `--yes` or
+  an interactive retype of the target, and all three require `--reason`. `purge` prints the deleted
+  row count and emits it as `deletedCount` under `--json`; the two worker commands emit the stored
+  `WorkerPauseResult`.
+- **Three read-only `admin` commands answer what a stalled durable handler is waiting on.**
+  `admin checkpoints <job-id>` renders the restart boundaries a handler passed and
+  `admin waits <job-id>` its durable timer waits, both narrowing to one record with `--name`.
+  `admin external-waits` is the fleet-wide question: every pending human decision and signal wait,
+  merged oldest first with a `KIND` column. Under `--json` it emits a `human` and a `signal` page
+  that advance independently through `--human-cursor` and `--signal-cursor`.
+- **The dashboard redrives a dead letter from the listing that shows it.** `dashboard/v1` gains
+  `redriveTask` and `redriveDeadLetters` additively; no existing procedure or field changes. The
+  discarded listing redrives one task from its row menu and a bounded page of the failures its
+  filters select from a control above the table. Both reach `Admin.redrive` and `Admin.redriveMany`
+  through `createDashboardOperatorControllers`, so the embedded, standalone, and demo hosts serve
+  them from one factory, and both are attributed to the operator the server authenticated rather
+  than to a name the browser supplied. `DashboardTaskController` gains `redriveTask` and
+  `redriveDeadLetters`, and `DashboardRedriveResult`, `DashboardRedriveFilter`, and
+  `DashboardRedriveBatch` are exported from `@stablemates/workhorse-dashboard-server/server` beside
+  the other controller result types.
+- `migrateSchema` accepts `lockTimeoutMs`, and `SCHEMA_MIGRATION_LOCK_TIMEOUT_MS` is its 5s
+  default. An `ALTER TABLE` takes `ACCESS EXCLUSIVE`, and PostgreSQL queues every later statement on
+  that table behind the waiting acquisition, so an unbounded wait turned one long worker
+  transaction into a stalled queue. The timeout bounds the migration body alone: waiting for a peer
+  migrator on the advisory lock stays unbounded, because that wait is expected. A step that gives
+  up rolls back atomically, so the recovery is to end the blocking transaction and rerun.
+
 ### Fixed
 
 - The published `@stablemates/workhorse` tarball no longer ships the benchmark suite.
@@ -169,6 +217,21 @@ and 24 and PostgreSQL 15 through 18.
 - The demo no longer replays the schema on startup against a database that already holds it.
 - The poll-cadence conformance fixture in `protocol/v1/runtime.json` holds the worker at each empty
   poll, so every language runtime's cadence test observes the same schedule.
+
+- The dashboard withholds a persisted attempt stack from the Events drawer too. `redactErrorStacks`
+  was applied in `jobDetail` and nowhere else, so a host that withheld a stack from task detail
+  handed the same stack to the same browser through `dashboard_event_detail_v1`, one click away.
+  `readDashboardEventDetail` now takes the flag and defaults it to false, exactly as
+  `readDashboardJobDetail` does.
+- `workhorse init` reads the lockfile the installer actually wrote when a project declares no
+  `packageManager`, instead of defaulting to pnpm, and the npm branch prints `npm exec --no --`
+  rather than the unqualified `npx` form the installation page warns about, which resolves whatever
+  package on the registry carries that name. It also states that `workhorse dashboard` needs
+  `@stablemates/workhorse-dashboard`, which nothing said before.
+- `ajv`'s `fast-uri` dependency moves off five High advisories inside the published closure. None is
+  reachable through Workhorse, which constructs `ajv` with `validateFormats: false` and requires
+  every `$ref` to be a local fragment, and which issues no request from a parsed URI at all. The
+  bump costs a lockfile line and is taken anyway.
 
 ### Upgrade notes
 

--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -35,6 +35,15 @@ Requires **schema v1** and Go **1.25** or newer.
 
 ### Changed
 
+- **`CheckCompatibility` takes the protocol versions the schema declares it serves.** Its signature
+  is now `func(*int, int, []int) error`. The check refused any schema newer than the version this
+  build was compiled against, which would have turned the first in-place migration into an outage
+  for the length of a rolling deployment. A build cannot know which later release stops serving it,
+  so the ceiling comes from the database: `workhorse.protocol_version` records the SQL protocol
+  versions the installed schema still serves, and a client whose protocol is absent from that list
+  refuses with `SchemaTooNew` below the oldest served version and `SchemaTooOld` above the newest.
+  An empty declaration enforces nothing. `AssertSchemaCompatible` reads both facts in one statement,
+  so its per-call check stays one round trip.
 - **Shared names for three parts of the public API.** Go was the odd language out on each one, so
   each moved to the spelling TypeScript and Python already share. `AssertCompatible` is now
   `AssertSchemaCompatible`. `HandlerContext.CreateChild`, `CreateChildren`, and `CreateChildrenAll`
@@ -55,7 +64,7 @@ Requires **schema v1** and Go **1.25** or newer.
   `DashboardQueueHealthReasonCode`, `DashboardRetentionPolicyImpact`, and
   `DashboardMaintenanceLoopCadences`. The file is generated, so it carries no aliases: a caller
   that names one of the eight updates the name. No request or response payload changes.
-- Those two entries and the removals above are the exported API changes since `0.1.0-beta.1`. The
+- The three entries above and the removals are the exported API changes since `0.1.0-beta.1`. The
   README states the unpinned install command and the schema install step, which the TypeScript CLI
   owns.
 - The dashboard backend's run-now action calls the audited `workhorse.run_task_now_v1` instead of
@@ -69,8 +78,20 @@ Requires **schema v1** and Go **1.25** or newer.
   `2026-09-02T14:30:00.000Z` and `...:00.123Z`. A client that compares or displays the string sees
   a different value; one that parses it does not.
 
+### Added
+
+- The `dashboard` package serves `redriveTask` and `redriveDeadLetters`, which the shared
+  `dashboard/v1` contract added this release. Both reach `Admin.Redrive` and `Admin.RedriveMany`: a
+  source the queue does not hold answers 404, and a bulk page reports every result plus the
+  continuation cursor the next page resumes from. The host lists both as mutations, so a
+  cross-origin or read-only request is refused before dispatch.
+
 ### Upgrade notes
 
+- **`CheckCompatibility` callers.** The function takes a third argument, the protocol versions the
+  installed schema declares it serves. `AssertSchemaCompatible` reads them for you; a caller that
+  invokes `CheckCompatibility` directly passes the list it read, or `nil` to enforce no ceiling,
+  which is what an empty declaration means.
 - **Schema version.** `0.1.0` stays at schema version 1, but its baseline is not the one the last
   beta installed: `workhorse.valid_tags` was renamed `workhorse.valid_tags_v1` and
   `workhorse.dashboard_run_task_now_v1` was removed. A database installed by any beta reports

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -19,6 +19,12 @@ Requires **schema v1** and Python **3.12** or newer.
 
 ### Added
 
+- The dashboard backend serves `redriveTask` and `redriveDeadLetters`, which the shared
+  `dashboard/v1` contract added this release. Both map onto `Admin.redrive` and
+  `Admin.redrive_many`: a source the queue does not hold answers 404, and a bulk page reports every
+  result plus the continuation cursor the next page resumes from. The host lists both as mutations,
+  so a cross-origin or read-only request is refused before dispatch. `workhorse.dashboard_v1` gains
+  their generated input and output types.
 - `workhorse.compatibility` publishes the startup schema check that the installation page tells every
   runtime to make. `assert_schema_compatible(connection)` takes a Psycopg connection, and
   `assert_schema_compatible_psycopg` and `assert_schema_compatible_asyncpg` name their asynchronous
@@ -43,6 +49,15 @@ Requires **schema v1** and Python **3.12** or newer.
 
 ### Changed
 
+- **The compatibility check declares a floor and no ceiling, and reads the ceiling from the
+  database.** It refused any schema newer than the version this build was compiled against, which
+  would have turned the first in-place migration into an outage for the length of a rolling
+  deployment. A build cannot know which later release stops serving it, so the installed schema
+  declares that instead: `workhorse.protocol_version` records the SQL protocol versions it still
+  serves, and a client whose protocol is absent from that list raises
+  `ProtocolCompatibilityError`. Below the oldest served version is `schema-too-new`; above the
+  newest is `schema-too-old`. A schema that records nothing enforces nothing. One statement returns
+  the schema version and the served list together, so the check stays one round trip.
 - The README states the unpinned install command and the schema install step, which the TypeScript
   CLI owns.
 


### PR DESCRIPTION
WH-569 reopened to re-cut the 0.1.0 candidate after WH-601, WH-604, WH-605, the twelve `0.x-only`
API cleanups, and the three Issues the Human gated the cut on all landed on `main`.

The version half needs no change. Every one of the nine `typescript/*/package.json` files,
`typescript/dashboard/app/package.json`, `WORKHORSE_VERSION`, `python/pyproject.toml`, and
`python/uv.lock` already carry `0.1.0`; every peer range is `>=0.1.0 <0.2.0`.

What a re-cut owes is the release notes. Twelve commits changed user-visible surface after the
notes were written, and none of them touched a changelog:

- `workhorse admin` gained `purge`, `pause-worker`, `resume-worker`, `checkpoints`, `waits`, and
  `external-waits` (WH-615, WH-617, WH-618) — every operator action that previously needed a
  browser.
- `dashboard/v1` gained `redriveTask` and `redriveDeadLetters`, served by the TypeScript, Python,
  and Go hosts (WH-616, WH-643).
- The compatibility check stopped enforcing a ceiling the client cannot know and started reading
  one the database declares, which changed Go's `CheckCompatibility` signature (WH-607).
- `migrateSchema` gained `lockTimeoutMs` with a 5s default (WH-607).
- The standalone dashboard server sets browser protections, the Events drawer stopped handing out
  a stack task detail withheld, and `fast-uri` moved off five High advisories in the published
  closure (WH-625).
- `workhorse init` reads the lockfile the installer wrote and prints `npm exec --no --` (WH-623).

The publication date stays 2026-09-14: `docs/compatibility.md` makes a slipped date a new
candidate, and that date has not slipped.

Docs-only diff across `CHANGELOG.md`, `python/CHANGELOG.md`, and `go/CHANGELOG.md`.

https://claude.ai/code/session_01NrwXqZrpNZepEbptFXGK5F
