### PR TITLE
[SM-700] Move every workflow action to a Node.js 24 runtime

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,9 +49,9 @@ jobs:
     env:
       WORKHORSE_BENCH_DATABASE_URL: postgres://workhorse:workhorse@localhost:5432/workhorse_bench
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -111,7 +111,7 @@ jobs:
       # needed to diagnose it.
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-smoke-${{ github.run_number }}
           path: benchmark-report.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,9 @@ jobs:
       go: ${{ steps.matrix.outputs.go }}
       packed: ${{ steps.matrix.outputs.packed }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -50,9 +50,9 @@ jobs:
     runs-on: depot-ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -84,9 +84,9 @@ jobs:
     runs-on: depot-ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -125,9 +125,9 @@ jobs:
     env:
       DATABASE_URL_TEST: postgres://workhorse:workhorse@localhost:5432/workhorse_test
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -176,9 +176,9 @@ jobs:
       DATABASE_URL_TEST: postgres://workhorse:workhorse@localhost:5432/workhorse_test
       UV_PYTHON: ${{ matrix.python }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -218,9 +218,9 @@ jobs:
     env:
       DATABASE_URL_TEST: postgres://workhorse:workhorse@localhost:5432/workhorse_test
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -259,9 +259,9 @@ jobs:
     env:
       DATABASE_URL_TEST: postgres://workhorse:workhorse@localhost:5432/workhorse_test
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -302,9 +302,9 @@ jobs:
     env:
       DATABASE_URL_TEST_PACKED: postgres://workhorse:workhorse@localhost:5432/workhorse_test_packed
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -335,9 +335,9 @@ jobs:
     env:
       DATABASE_URL_PRIMARY: postgres://workhorse:workhorse@localhost:5432/workhorse_dev_primary
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -50,9 +50,9 @@ jobs:
             echo "No successful main CI push run exists for $GITHUB_SHA" >&2
             exit 1
           fi
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -60,7 +60,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm python:release-check
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: python-distributions
           path: python/dist/*
@@ -77,7 +77,7 @@ jobs:
       - uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: false
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: python-distributions
           path: python/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,9 @@ jobs:
             echo "No successful main CI push run exists for $GITHUB_SHA" >&2
             exit 1
           fi
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -59,7 +59,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm npm:release-check
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: tarballs
           path: dist-tarballs/*.tgz
@@ -78,15 +78,15 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
           registry-url: https://registry.npmjs.org
       - run: pnpm install --frozen-lockfile
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: tarballs
           path: dist-tarballs
@@ -112,9 +112,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm

--- a/typescript/core/test/schema-migrations.test.ts
+++ b/typescript/core/test/schema-migrations.test.ts
@@ -596,7 +596,8 @@ describe("schema migrations", () => {
         });
 
         expect(outcome.kind).toBe("applied");
-        if (outcome.kind === "applied") expect(outcome.step.file).toBe("0003-retire-probe.sql");
+        if (outcome.kind !== "applied") throw new Error("expected the contract step to be applied");
+        expect(outcome.step.file).toBe("0003-retire-probe.sql");
         const state = await contractDatabase.pool.query<{
           version: number;
           probe: string | null;
@@ -652,11 +653,12 @@ describe("schema migrations", () => {
         const outcome = await planSchemaContract(contractDatabase.pool, plan);
 
         expect(outcome.kind).toBe("unconfirmed");
-        if (outcome.kind === "unconfirmed") {
-          // The live worker on the retiring protocol is named; the one outside its lease and the
-          // one on a surviving protocol are not.
-          expect(outcome.workers.map((worker) => worker.workerId)).toEqual([retiring]);
+        if (outcome.kind !== "unconfirmed") {
+          throw new Error("expected the contract step to be refused");
         }
+        // The live worker on the retiring protocol is named; the one outside its lease and the
+        // one on a surviving protocol are not.
+        expect(outcome.workers.map((worker) => worker.workerId)).toEqual([retiring]);
         expect(
           await contractDatabase.pool
             .query<{ version: number }>("SELECT version FROM workhorse.schema_version")
@@ -697,10 +699,11 @@ describe("schema migrations", () => {
         });
 
         expect(outcome.kind).toBe("applied");
-        if (outcome.kind === "applied") {
-          // The workers the step was applied past are still reported, not silently ignored.
-          expect(outcome.workers.map((worker) => worker.workerId)).toEqual([retiring]);
+        if (outcome.kind !== "applied") {
+          throw new Error("expected the contract step to be applied");
         }
+        // The workers the step was applied past are still reported, not silently ignored.
+        expect(outcome.workers.map((worker) => worker.workerId)).toEqual([retiring]);
       } finally {
         await deregisterContractWorker(retiring);
         await contractDatabase.pool.query(


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` v4 → v7, `actions/setup-node` v4 → v7, `pnpm/action-setup` v4 → v6, `actions/upload-artifact` v4 → v7, `actions/download-artifact` v4 → v8 across `ci.yml`, `release.yml`, `release-python.yml`, and `benchmark.yml`. Every pinned action now declares `runs.using: node24`, ending the forced-fallback deprecation warning on each job.
- Reviewed the skipped majors' release notes: checkout v7's fork-PR block covers `pull_request_target`/`workflow_run` (unused here), setup-node's auto-cache is superseded by the explicit `cache: pnpm` input, download-artifact v8 hardens hash-mismatch into an error, and pnpm/action-setup v6 keeps the v4 input contract and still installs pnpm 10 from `packageManager`.
- Also fixes SM-709: three `vitest/no-conditional-expect` errors in `schema-migrations.test.ts` that have kept `main` red since e1619240 and block the "CI passes on main" acceptance item.

#### Test plan

- [x] `CI / required` passes on this PR with no Node.js runtime deprecation warning
- [ ] After merge: `CI / required` passes on `main`
- [ ] Dry-run `release.yml` and `release-python.yml` (`workflow_dispatch`, `dry-run=true`) on `main`

Generated with [Devin](https://devin.ai)