### PR TITLE
Remove test helpers left unused by the pooling schema-reset change

### DIFF
--- a/typescript/core/test/support/db.ts
+++ b/typescript/core/test/support/db.ts
@@ -107,24 +107,7 @@ export function createDatabaseTestHarness(
   };
 }
 
-/**
- * Create a second empty database beside the harness one, for tests that need a clean database
- * after setup — schema installation only runs on one. The name must keep the test-purpose marker.
- */
-export async function createEmptyTestDatabase(sourceUrl: string, name: string): Promise<void> {
-  const target = new URL(sourceUrl);
-  target.pathname = `/${name}`;
-  assertLocalDatabasePurpose(target.toString(), "test");
-  const admin = adminPool(sourceUrl);
-  try {
-    await dropDatabaseWithAdmin(admin, name);
-    await admin.query(`CREATE DATABASE ${identifier(name)}`);
-  } finally {
-    await admin.end();
-  }
-}
-
-/** Drop a database previously created by {@link createEmptyTestDatabase}. */
+/** Drop a scratch test database by name. The name must keep the test-purpose marker. */
 export async function dropTestDatabase(sourceUrl: string, name: string): Promise<void> {
   await dropDatabase(sourceUrl, name);
 }
@@ -146,7 +129,7 @@ export async function ensureTestDatabase(sourceUrl: string, name: string): Promi
   }
 }
 
-export { namedTestDatabaseUrl, poolingScratchName } from "../../src/local-database.js";
+export { poolingScratchName } from "../../src/local-database.js";
 
 async function prepareCurrentHistoryPartitions(pool: Pool): Promise<void> {
   await pool.query(


### PR DESCRIPTION
## Summary
- `createEmptyTestDatabase` lost its last caller when the pooling schema lane switched to `DROP SCHEMA` resets, and the `namedTestDatabaseUrl` re-export became dead once the fixture imported it from `local-database.js` directly.
- Knip flags both as unused exports, which failed the lint job on main after #74 merged.

#### Test plan
- [x] `pnpm lint:dead-code` exits 0
- [x] oxlint clean on the touched file
- [ ] CI format/lint job green

Generated with [Devin](https://devin.ai)