### PR TITLE
SM-712: Make the Python signal-drain process tests deterministic

### DIFF
--- a/python/tests/fixtures/process_runner.py
+++ b/python/tests/fixtures/process_runner.py
@@ -8,6 +8,10 @@ from threading import Event
 from workhorse import run_worker_process
 
 
+def _emit(message: str) -> None:
+    os.write(sys.stdout.fileno(), message.encode() + b"\n")
+
+
 class FixtureWorker:
     def __init__(self, *, mode: str) -> None:
         self._mode = mode
@@ -17,7 +21,7 @@ class FixtureWorker:
 
     def _announce_ready(self) -> None:
         if not self._ready:
-            print("ready", flush=True)
+            _emit("ready")
             self._ready = True
 
     def _stop_version_snapshot(self) -> int:
@@ -27,7 +31,7 @@ class FixtureWorker:
         self._announce_ready()
         if self._mode == "pre-run-signal":
             os.kill(os.getpid(), signal.SIGTERM)
-        if requested_stop_version != self._stop_version:
+        if self._mode != "block" and requested_stop_version != self._stop_version:
             return
         self._finished.wait()
 
@@ -38,7 +42,7 @@ class FixtureWorker:
         self._run_continuously(self._stop_version_snapshot())
 
     def stop(self) -> None:
-        print("stopping", flush=True)
+        _emit("stopping")
         self._stop_version += 1
         if self._mode == "drain":
             self._finished.set()

--- a/python/tests/test_worker_process.py
+++ b/python/tests/test_worker_process.py
@@ -37,8 +37,8 @@ def _finish(process: subprocess.Popen[str]) -> tuple[str, str]:
         process.wait(timeout=5)
     except subprocess.TimeoutExpired:
         process.kill()
-        process.communicate()
-        raise
+        stdout, stderr = process.communicate()
+        pytest.fail(f"process did not exit within 5s; stdout: {stdout!r} stderr: {stderr!r}")
     assert process.stdout is not None
     assert process.stderr is not None
     return process.stdout.read(), process.stderr.read()
@@ -55,12 +55,12 @@ def _kill_and_reap(process: subprocess.Popen[str]) -> None:
 def test_first_termination_signal_stops_claims_and_allows_a_graceful_drain(
     termination_signal: signal.Signals,
 ) -> None:
-    process = _start_fixture("drain", 1_000)
+    process = _start_fixture("drain", 30_000)
 
     process.send_signal(termination_signal)
 
     stdout, stderr = _finish(process)
-    assert process.returncode == 0
+    assert process.returncode == 0, f"stdout: {stdout!r} stderr: {stderr!r}"
     assert stdout.strip() == "stopping"
     assert stderr == ""
 
@@ -74,15 +74,15 @@ def test_second_termination_signal_uses_its_conventional_exit_code(
     second_signal: signal.Signals,
     exit_code: int,
 ) -> None:
-    process = _start_fixture("block", 5_000)
+    process = _start_fixture("block", 30_000)
 
     process.send_signal(signal.SIGTERM)
     assert process.stdout is not None
     assert process.stdout.readline().strip() == "stopping"
     process.send_signal(second_signal)
 
-    _finish(process)
-    assert process.returncode == exit_code
+    stdout, stderr = _finish(process)
+    assert process.returncode == exit_code, f"stdout: {stdout!r} stderr: {stderr!r}"
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX process signals are required")
@@ -91,8 +91,8 @@ def test_missed_graceful_drain_deadline_exits_with_failure() -> None:
 
     process.send_signal(signal.SIGTERM)
 
-    _finish(process)
-    assert process.returncode == 1
+    stdout, stderr = _finish(process)
+    assert process.returncode == 1, f"stdout: {stdout!r} stderr: {stderr!r}"
 
 
 def test_shutdown_deadline_rejects_values_outside_the_process_contract() -> None:
@@ -102,10 +102,10 @@ def test_shutdown_deadline_rejects_values_outside_the_process_contract() -> None
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX process signals are required")
 def test_signal_between_handler_installation_and_worker_run_is_not_lost() -> None:
-    process = _start_fixture("pre-run-signal", 1_000)
+    process = _start_fixture("pre-run-signal", 30_000)
 
     stdout, stderr = _finish(process)
-    assert process.returncode == 0
+    assert process.returncode == 0, f"stdout: {stdout!r} stderr: {stderr!r}"
     assert stdout.strip() == "stopping"
     assert stderr == ""
 


### PR DESCRIPTION
## Summary

- Fixture emits `ready`/`stopping` via `os.write` instead of buffered `print`: the signal handler ran `stop()` while the main thread was still inside `print("ready")`, and the handler's own print re-entered the same `BufferedWriter` — `RuntimeError: reentrant call`, exit 1, traceback discarded by the assertion. That matches the CI flake on run 34616710596.
- `block` mode no longer short-circuits on the stop-version check: a signal landing between the ready announcement and `_finished.wait()` let it exit 0, racing the missed-deadline and second-signal tests.
- Drain-side `shutdown_timeout_ms` raised 1s → 30s so the 5s reap wait is always the backstop.
- Every returncode assertion and the reap-timeout path now report captured stdout/stderr.

#### Test plan

- [x] Reproduced ~79 failures / 100 file-level pytest runs under 32-way CPU oversubscription before the fix; ~80 iterations after, zero failures
- [x] `ruff check`, `ruff format --check`, mypy, and Python unit scope (91 tests) pass via lefthook

Follow-up filed as SM-714: `Worker.stop()` acquires `_state_lock` and emits OTel logs inside the signal handler, so the same hazard class exists in `run_worker_process`.